### PR TITLE
Add scenario budget summary, interactive animations, and new presets

### DIFF
--- a/src/components/Editor.jsx
+++ b/src/components/Editor.jsx
@@ -49,7 +49,7 @@ function StageCard({ stage, zones, onStageChange, onStageRemove, onNoteChange, o
   };
 
   return (
-    <div className="rounded-2xl border border-slate-800 bg-slate-900/70 p-4">
+    <div className="rounded-2xl border border-slate-800 bg-slate-900/70 p-4 card-animated">
       <div className="flex items-start justify-between gap-3">
         <div className="flex-1 space-y-2">
           <input
@@ -124,7 +124,7 @@ function StageCard({ stage, zones, onStageChange, onStageRemove, onNoteChange, o
         </div>
         <button
           onClick={() => onStageRemove(stage.id)}
-          className="rounded-lg border border-rose-600/40 bg-rose-500/10 p-2 text-rose-200 hover:bg-rose-500/20"
+          className="transform rounded-lg border border-rose-600/40 bg-rose-500/10 p-2 text-rose-200 transition hover:-translate-y-0.5 hover:bg-rose-500/20 active:scale-95"
         >
           <TrashIcon className="h-4 w-4" />
         </button>
@@ -135,7 +135,7 @@ function StageCard({ stage, zones, onStageChange, onStageRemove, onNoteChange, o
         </div>
         <button
           onClick={() => onFocusStage(stage.id)}
-          className="rounded-md border border-cyan-500/40 bg-cyan-500/10 px-3 py-1 text-xs text-cyan-200 hover:bg-cyan-500/20"
+          className="transform rounded-md border border-cyan-500/40 bg-cyan-500/10 px-3 py-1 text-xs text-cyan-200 transition hover:-translate-y-0.5 hover:bg-cyan-500/20 active:scale-95"
         >
           Фокус на визуализации
         </button>
@@ -160,7 +160,7 @@ function Editor({ title, stages, zones, onStageChange, onStageAdd, onStageRemove
         <h2 className="text-lg font-semibold text-slate-100">{title}</h2>
         <button
           onClick={() => onStageAdd()}
-          className="flex items-center gap-2 rounded-lg border border-emerald-500/40 bg-emerald-500/10 px-3 py-2 text-sm text-emerald-200 hover:bg-emerald-500/20"
+          className="flex items-center gap-2 rounded-lg border border-emerald-500/40 bg-emerald-500/10 px-3 py-2 text-sm text-emerald-200 transition hover:-translate-y-0.5 hover:bg-emerald-500/20 active:scale-95"
         >
           <PlusIcon className="h-4 w-4" /> Добавить этап
         </button>

--- a/src/components/FunnelSVG.jsx
+++ b/src/components/FunnelSVG.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import { useMemo } from 'react';
+import { clsx } from 'clsx';
 
 const StageHeight = 140;
 const StageGap = 18;
@@ -111,7 +112,9 @@ function FunnelSVG({ stages, zones, presentationIndex, focusedStageId, onStageFo
                   stroke={isHighlighted ? '#38bdf8' : '#1e293b'}
                   strokeWidth={isHighlighted ? 3.5 : 1.5}
                   onClick={() => onStageFocus?.(stage.id)}
-                  className="cursor-pointer transition"
+                  className={clsx('stage-hover', {
+                    'filter drop-shadow-[0_18px_32px_rgba(59,130,246,0.35)]': isHighlighted,
+                  })}
                 />
                 <path
                   d={`M${xTopImproved},${yTop} L${xTopImproved + improvedTopWidth},${yTop} L${xBottomImproved + improvedBottomWidth},${yBottom} L${xBottomImproved},${yBottom} Z`}

--- a/src/components/InsightsPanel.jsx
+++ b/src/components/InsightsPanel.jsx
@@ -16,13 +16,13 @@ function InsightsPanel({ metrics, zones, locale, trafficChannels }) {
   const retention = retentionSummary ?? null;
   return (
     <div className="mt-6 grid gap-4 lg:grid-cols-4">
-      <div className="rounded-2xl border border-slate-800 bg-slate-950/50 p-4">
+      <div className="rounded-2xl border border-slate-800 bg-slate-950/50 p-4 card-animated">
         <div className="flex items-center gap-2 text-sm font-semibold text-slate-100">
           <LightBulbIcon className="h-5 w-5 text-amber-300" /> Авто-инсайт
         </div>
         <p className="mt-2 text-sm text-slate-300">{insight}</p>
       </div>
-      <div className="rounded-2xl border border-slate-800 bg-slate-950/50 p-4">
+      <div className="rounded-2xl border border-slate-800 bg-slate-950/50 p-4 card-animated">
         <h3 className="text-sm font-semibold text-slate-100">Бутылочное горлышко</h3>
         {bottleneck ? (
           <dl className="mt-2 space-y-1 text-sm text-slate-300">
@@ -41,7 +41,7 @@ function InsightsPanel({ metrics, zones, locale, trafficChannels }) {
           <p className="mt-2 text-sm text-slate-500">Горлышко не обнаружено.</p>
         )}
       </div>
-      <div className="rounded-2xl border border-slate-800 bg-slate-950/50 p-4">
+      <div className="rounded-2xl border border-slate-800 bg-slate-950/50 p-4 card-animated">
         <h3 className="text-sm font-semibold text-slate-100">Повторные касания / RFM</h3>
         {retention ? (
           <dl className="mt-3 space-y-2 text-xs text-slate-300">
@@ -78,7 +78,7 @@ function InsightsPanel({ metrics, zones, locale, trafficChannels }) {
           <p className="mt-2 text-sm text-slate-500">Добавьте этап с зоной «Повторные касания».</p>
         )}
       </div>
-      <div className="rounded-2xl border border-slate-800 bg-slate-950/50 p-4">
+      <div className="rounded-2xl border border-slate-800 bg-slate-950/50 p-4 card-animated">
         <h3 className="text-sm font-semibold text-slate-100">Бенчмарки зон</h3>
         <ul className="mt-2 space-y-2 text-xs text-slate-400">
           {zones.map((zone) => {
@@ -98,7 +98,7 @@ function InsightsPanel({ metrics, zones, locale, trafficChannels }) {
         </ul>
       </div>
       {trafficChannels?.length ? (
-        <div className="rounded-2xl border border-slate-800 bg-slate-950/50 p-4">
+        <div className="rounded-2xl border border-slate-800 bg-slate-950/50 p-4 card-animated">
           <h3 className="flex items-center gap-2 text-sm font-semibold text-slate-100">
             <ChartPieIcon className="h-4 w-4 text-cyan-300" /> Каналы трафика
           </h3>

--- a/src/components/KPIs.jsx
+++ b/src/components/KPIs.jsx
@@ -15,7 +15,7 @@ function KPIBlock({ label, base, improved, accent }) {
   const delta = (improved ?? 0) - (base ?? 0);
   const deltaPercent = base ? (delta / base) * 100 : 0;
   return (
-    <div className="rounded-2xl border border-slate-800 bg-slate-900/70 p-4">
+    <div className="rounded-2xl border border-slate-800 bg-slate-900/70 p-4 card-animated">
       <div className="text-xs uppercase tracking-wide text-slate-400">{label}</div>
       <div className="mt-2 text-2xl font-semibold text-slate-100">{KPIBlock.formatNumber(improved ?? base)}</div>
       <div className="mt-1 text-sm text-slate-400">База: {KPIBlock.formatNumber(base)}</div>
@@ -49,7 +49,10 @@ function KPIs({ title, metrics, finances, onFinancesChange, locale }) {
       <div className="flex flex-wrap items-center justify-between gap-4">
         <h2 className="text-lg font-semibold text-slate-100">{title}</h2>
         <div className="flex flex-wrap gap-2 text-xs text-slate-400">
-          <button onClick={() => window.print()} className="rounded-md border border-slate-700 px-3 py-1 hover:border-cyan-400">
+          <button
+            onClick={() => window.print()}
+            className="transform rounded-md border border-slate-700 px-3 py-1 transition hover:-translate-y-0.5 hover:border-cyan-400 active:scale-95"
+          >
             Экспорт PDF/PNG
           </button>
           <div className="rounded-md border border-slate-800 bg-slate-900/80 px-3 py-1">
@@ -76,7 +79,7 @@ function KPIs({ title, metrics, finances, onFinancesChange, locale }) {
       </div>
 
       <div className="grid gap-4 lg:grid-cols-3">
-        <div className="rounded-2xl border border-slate-800 bg-slate-900/70 p-4">
+        <div className="rounded-2xl border border-slate-800 bg-slate-900/70 p-4 card-animated">
           <h3 className="text-sm font-semibold text-slate-200">Финансовые параметры</h3>
           <div className="mt-3 space-y-3 text-sm">
             <label className="flex items-center justify-between gap-3">
@@ -117,7 +120,7 @@ function KPIs({ title, metrics, finances, onFinancesChange, locale }) {
             </label>
           </div>
         </div>
-        <div className="rounded-2xl border border-slate-800 bg-slate-900/70 p-4">
+        <div className="rounded-2xl border border-slate-800 bg-slate-900/70 p-4 card-animated">
           <h3 className="text-sm font-semibold text-slate-200">Денежный поток</h3>
           <dl className="mt-3 space-y-2 text-sm text-slate-300">
             <div className="flex items-center justify-between">
@@ -133,12 +136,24 @@ function KPIs({ title, metrics, finances, onFinancesChange, locale }) {
               <dd>{formatNumber(metrics.spendBase, 0)} ₽ → {formatNumber(metrics.spendImproved, 0)} ₽</dd>
             </div>
             <div className="flex items-center justify-between">
+              <dt>Доля выручки</dt>
+              <dd>
+                {metrics.marketingBudgetShare != null
+                  ? `${formatNumber((metrics.marketingBudgetShare ?? 0) * 100)}%`
+                  : '—'}{' '}
+                <span className="text-xs text-cyan-200">{metrics.marketingBudgetLabel}</span>
+              </dd>
+            </div>
+            <div className="rounded-lg border border-cyan-500/30 bg-cyan-500/10 px-3 py-2 text-xs text-cyan-200">
+              {metrics.marketingBudgetStatus}
+            </div>
+            <div className="flex items-center justify-between">
               <dt>Маржинальный доход</dt>
               <dd>{formatNumber(metrics.grossMarginBase, 0)} ₽ → {formatNumber(metrics.grossMarginImproved, 0)} ₽</dd>
             </div>
           </dl>
         </div>
-        <div className="rounded-2xl border border-slate-800 bg-slate-900/70 p-4">
+        <div className="rounded-2xl border border-slate-800 bg-slate-900/70 p-4 card-animated">
           <h3 className="text-sm font-semibold text-slate-200">Unit-экономика</h3>
           <ul className="mt-3 space-y-2 text-sm text-slate-300">
             <li>CAC: {formatNumber(finances.cac)} ₽</li>

--- a/src/components/Levers.jsx
+++ b/src/components/Levers.jsx
@@ -28,7 +28,7 @@ function Levers({ title, subtitle, levers, activeLevers, onToggle, stages, local
   }, {});
 
   return (
-    <section className="space-y-3 rounded-2xl border border-slate-800 bg-slate-900/70 p-4">
+    <section className="space-y-3 rounded-2xl border border-slate-800 bg-slate-900/70 p-4 card-animated">
       <div className="flex items-center justify-between">
         <h2 className="text-lg font-semibold text-slate-100">{title}</h2>
         <span className="text-xs uppercase tracking-wide text-slate-500">{subtitle ?? copy.subtitle}</span>
@@ -40,25 +40,29 @@ function Levers({ title, subtitle, levers, activeLevers, onToggle, stages, local
           return (
             <div
               key={lever.id}
-              className={`rounded-2xl border ${isActive ? 'border-emerald-500/60 bg-emerald-500/10' : 'border-slate-800 bg-slate-950/40'} p-4`}
+              className={`rounded-2xl border ${isActive ? 'border-emerald-500/60 bg-emerald-500/10' : 'border-slate-800 bg-slate-950/40'} p-4 card-animated`}
             >
               <div className="flex items-start justify-between gap-3">
                 <div>
                   <div className="flex items-center gap-2 text-sm font-semibold text-slate-100">
-                  <SparklesIcon className="h-4 w-4 text-emerald-300" /> {lever.name}
+                    <SparklesIcon className="h-4 w-4 text-emerald-300" /> {lever.name}
+                  </div>
+                  <p className="mt-1 text-xs text-slate-400">{lever.description}</p>
+                  <p className="mt-2 text-xs text-slate-400">
+                    {copy.stageLabel}: <span className="text-slate-200">{stage?.name ?? '—'}</span>
+                  </p>
                 </div>
-                <p className="mt-1 text-xs text-slate-400">{lever.description}</p>
-                <p className="mt-2 text-xs text-slate-400">
-                  {copy.stageLabel}: <span className="text-slate-200">{stage?.name ?? '—'}</span>
-                </p>
+                <button
+                  onClick={() => onToggle(lever.id)}
+                  className={`transform rounded-lg border px-3 py-2 text-xs font-semibold transition active:scale-95 ${
+                    isActive
+                      ? 'border-emerald-400 bg-emerald-500/20 text-emerald-100 hover:-translate-y-0.5'
+                      : 'border-slate-700 bg-slate-900/60 text-slate-200 hover:-translate-y-0.5 hover:border-emerald-400'
+                  }`}
+                >
+                  {isActive ? copy.active : copy.activate}
+                </button>
               </div>
-              <button
-                onClick={() => onToggle(lever.id)}
-                className={`rounded-lg border px-3 py-2 text-xs font-semibold transition ${isActive ? 'border-emerald-400 bg-emerald-500/20 text-emerald-100' : 'border-slate-700 bg-slate-900/60 text-slate-200 hover:border-emerald-400'}`}
-              >
-                {isActive ? copy.active : copy.activate}
-              </button>
-            </div>
             <div className="mt-3 flex flex-wrap items-center gap-3 text-xs text-slate-400">
               <span className="rounded-full border border-emerald-400/60 bg-emerald-400/10 px-3 py-1 text-emerald-200">
                 +{numberFormatter.format(lever.conversionBoost)} п.п. конверсии

--- a/src/components/NotesTasks.jsx
+++ b/src/components/NotesTasks.jsx
@@ -39,26 +39,26 @@ function NotesTasks({ title, stages, onTasksChange, onExportTasks, onFocusStage 
   };
 
   return (
-    <section className="space-y-4 rounded-2xl border border-slate-800 bg-slate-900/70 p-4">
+    <section className="space-y-4 rounded-2xl border border-slate-800 bg-slate-900/70 p-4 card-animated">
       <div className="flex items-center justify-between">
         <h2 className="text-lg font-semibold text-slate-100">{title}</h2>
         <div className="flex gap-2 text-xs text-slate-400">
           <button
             onClick={() => onExportTasks('json')}
-            className="flex items-center gap-2 rounded-md border border-slate-700 px-3 py-1 hover:border-cyan-400"
+            className="flex items-center gap-2 rounded-md border border-slate-700 px-3 py-1 transition hover:-translate-y-0.5 hover:border-cyan-400 active:scale-95"
           >
             <ArrowDownTrayIcon className="h-4 w-4" /> JSON
           </button>
           <button
             onClick={() => onExportTasks('csv')}
-            className="flex items-center gap-2 rounded-md border border-slate-700 px-3 py-1 hover:border-cyan-400"
+            className="flex items-center gap-2 rounded-md border border-slate-700 px-3 py-1 transition hover:-translate-y-0.5 hover:border-cyan-400 active:scale-95"
           >
             <ArrowDownTrayIcon className="h-4 w-4" /> CSV
           </button>
         </div>
       </div>
 
-      <div className="rounded-xl border border-slate-800 bg-slate-950/40 p-3 text-sm text-slate-200">
+      <div className="rounded-xl border border-slate-800 bg-slate-950/40 p-3 text-sm text-slate-200 card-animated">
         <div className="flex flex-wrap items-center gap-2">
           <select
             value={newTaskStage}
@@ -79,7 +79,7 @@ function NotesTasks({ title, stages, onTasksChange, onExportTasks, onFocusStage 
           />
           <button
             onClick={handleAddTask}
-            className="flex items-center gap-2 rounded border border-emerald-500/40 bg-emerald-500/10 px-3 py-1 text-xs text-emerald-200 hover:bg-emerald-500/20"
+            className="flex items-center gap-2 rounded border border-emerald-500/40 bg-emerald-500/10 px-3 py-1 text-xs text-emerald-200 transition hover:-translate-y-0.5 hover:bg-emerald-500/20 active:scale-95"
           >
             <PlusIcon className="h-4 w-4" /> Добавить
           </button>
@@ -88,9 +88,12 @@ function NotesTasks({ title, stages, onTasksChange, onExportTasks, onFocusStage 
 
       <div className="space-y-3 text-sm text-slate-200">
         {stages.map((stage) => (
-          <div key={stage.id} className="rounded-xl border border-slate-800 bg-slate-950/40 p-3">
+          <div key={stage.id} className="rounded-xl border border-slate-800 bg-slate-950/40 p-3 card-animated">
             <div className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-500">
-              <button onClick={() => onFocusStage(stage.id)} className="text-left text-slate-300 hover:text-cyan-300">
+              <button
+                onClick={() => onFocusStage(stage.id)}
+                className="text-left text-slate-300 transition hover:-translate-y-0.5 hover:text-cyan-300"
+              >
                 {stage.name}
               </button>
               <span>{(stage.tasks ?? []).length} задач</span>
@@ -105,7 +108,10 @@ function NotesTasks({ title, stages, onTasksChange, onExportTasks, onFocusStage 
                     className="mt-[2px] rounded border-slate-600 bg-slate-900"
                   />
                   <span className={task.done ? 'line-through text-slate-500' : ''}>{task.text}</span>
-                  <button onClick={() => removeTask(stage.id, task.id)} className="ml-auto text-slate-500 hover:text-rose-400">
+                  <button
+                    onClick={() => removeTask(stage.id, task.id)}
+                    className="ml-auto text-slate-500 transition hover:-translate-y-0.5 hover:text-rose-400"
+                  >
                     ×
                   </button>
                 </label>

--- a/src/components/ScenarioSummary.jsx
+++ b/src/components/ScenarioSummary.jsx
@@ -1,0 +1,139 @@
+import PropTypes from 'prop-types';
+import { useMemo } from 'react';
+import { BanknotesIcon, BoltIcon, RocketLaunchIcon } from '@heroicons/react/24/outline';
+
+function createFormatter(locale, options = {}) {
+  try {
+    return new Intl.NumberFormat(locale ?? 'ru-RU', options);
+  } catch (error) {
+    return new Intl.NumberFormat('ru-RU', options);
+  }
+}
+
+function ScenarioSummary({ scenario, metrics, locale }) {
+  if (!metrics) return null;
+  const numberFormatter = useMemo(() => createFormatter(locale, { maximumFractionDigits: 1 }), [locale]);
+  const currencyFormatter = useMemo(() => createFormatter(locale, { maximumFractionDigits: 0 }), [locale]);
+
+  const scenarioName = scenario?.name ?? 'Сценарий';
+  const sharePercent = metrics.marketingBudgetShare != null ? metrics.marketingBudgetShare * 100 : null;
+  const budgetLabel = metrics.marketingBudgetLabel ?? '—';
+  const budgetStatus = metrics.marketingBudgetStatus ?? '—';
+  const spendBase = metrics.spendBase ?? 0;
+  const spendImproved = metrics.spendImproved ?? spendBase;
+  const description = metrics.scenarioDescription ?? scenario?.description ?? '';
+  const plays = metrics.scenarioPlays ?? [];
+  const trafficMix = metrics.trafficMix ?? [];
+
+  return (
+    <section className="mt-4 rounded-3xl border border-slate-800 bg-slate-900/60 p-6 card-animated">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div className="max-w-2xl space-y-2">
+          <span className="text-xs uppercase tracking-wide text-slate-500">Активный сценарий</span>
+          <h2 className="text-xl font-semibold text-slate-50">{scenarioName}</h2>
+          {description && <p className="text-sm text-slate-300">{description}</p>}
+        </div>
+        <div className="pulse-ring inline-flex flex-col gap-1 rounded-full border border-cyan-500/40 bg-cyan-500/10 px-5 py-4 text-cyan-100">
+          <span className="text-xs uppercase tracking-wide text-cyan-200/70">Бюджет</span>
+          <span className="text-2xl font-semibold">
+            {sharePercent != null ? `${numberFormatter.format(sharePercent)}%` : '—'}
+          </span>
+          <span className="text-[11px] uppercase tracking-wide text-cyan-200/70">{budgetLabel}</span>
+        </div>
+      </div>
+
+      <div className="mt-6 grid gap-5 lg:grid-cols-[1.1fr_1fr]">
+        <div className="space-y-4">
+          <div className="rounded-2xl border border-slate-800 bg-slate-950/60 p-4 card-animated">
+            <div className="flex items-center gap-2 text-sm font-semibold text-slate-100">
+              <BanknotesIcon className="h-5 w-5 text-emerald-300" /> Инвестиции
+            </div>
+            <dl className="mt-3 space-y-2 text-sm text-slate-300">
+              <div className="flex items-center justify-between">
+                <dt>База</dt>
+                <dd className="font-medium text-slate-100">{currencyFormatter.format(spendBase)} ₽</dd>
+              </div>
+              <div className="flex items-center justify-between">
+                <dt>Сценарий</dt>
+                <dd className="font-medium text-emerald-300">{currencyFormatter.format(spendImproved)} ₽</dd>
+              </div>
+              <div className="rounded-lg border border-slate-800 bg-slate-900/70 px-3 py-2 text-xs text-cyan-200">
+                {budgetStatus}
+              </div>
+            </dl>
+          </div>
+
+          {plays?.length ? (
+            <div className="rounded-2xl border border-slate-800 bg-slate-950/60 p-4 card-animated">
+              <div className="flex items-center gap-2 text-sm font-semibold text-slate-100">
+                <BoltIcon className="h-5 w-5 text-amber-300" /> Ключевые плейбуки
+              </div>
+              <ul className="mt-3 flex flex-wrap gap-2 text-xs">
+                {plays.map((play) => (
+                  <li
+                    key={play}
+                    className="rounded-full border border-amber-400/40 bg-amber-500/10 px-3 py-1 text-amber-200 transition hover:-translate-y-0.5 hover:border-amber-300"
+                  >
+                    {play}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+        </div>
+
+        <div className="rounded-2xl border border-slate-800 bg-slate-950/60 p-4 card-animated">
+          <div className="flex items-center gap-2 text-sm font-semibold text-slate-100">
+            <RocketLaunchIcon className="h-5 w-5 text-cyan-300" /> Микс каналов в сценарии
+          </div>
+          {trafficMix?.length ? (
+            <ul className="mt-4 space-y-3 text-sm text-slate-200">
+              {trafficMix.map((channel) => (
+                <li key={channel.id} className="space-y-1">
+                  <div className="flex items-center justify-between gap-3">
+                    <span className="font-medium">{channel.name}</span>
+                    <span className="text-xs text-cyan-200">
+                      {numberFormatter.format(channel.share ?? 0)}%
+                    </span>
+                  </div>
+                  {channel.note && <p className="text-[11px] text-slate-500">{channel.note}</p>}
+                  <div className="h-2 w-full rounded-full bg-slate-800">
+                    <div
+                      className="h-2 rounded-full bg-gradient-to-r from-cyan-500 to-emerald-400"
+                      style={{ width: `${Math.max(5, Math.min(100, channel.share ?? 0))}%` }}
+                    />
+                  </div>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="mt-3 text-sm text-slate-500">Добавьте каналы, чтобы отследить распределение трафика.</p>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+ScenarioSummary.propTypes = {
+  scenario: PropTypes.object,
+  metrics: PropTypes.shape({
+    marketingBudgetShare: PropTypes.number,
+    marketingBudgetLabel: PropTypes.string,
+    marketingBudgetStatus: PropTypes.string,
+    spendBase: PropTypes.number,
+    spendImproved: PropTypes.number,
+    scenarioDescription: PropTypes.string,
+    scenarioPlays: PropTypes.arrayOf(PropTypes.string),
+    trafficMix: PropTypes.arrayOf(PropTypes.object),
+  }),
+  locale: PropTypes.string,
+};
+
+ScenarioSummary.defaultProps = {
+  scenario: null,
+  metrics: null,
+  locale: 'ru-RU',
+};
+
+export default ScenarioSummary;

--- a/src/components/ScenarioTabs.jsx
+++ b/src/components/ScenarioTabs.jsx
@@ -3,7 +3,7 @@ import { clsx } from 'clsx';
 
 function ScenarioTabs({ label, scenarios, activeScenarioId, onScenarioChange }) {
   return (
-    <div className="mt-6 flex flex-wrap items-center gap-3 rounded-2xl border border-slate-800 bg-slate-900/70 px-4 py-3">
+    <div className="mt-6 flex flex-wrap items-center gap-3 rounded-2xl border border-slate-800 bg-slate-900/70 px-4 py-3 card-animated">
       <span className="text-xs uppercase tracking-wide text-slate-500">{label}</span>
       <div className="flex flex-wrap gap-2">
         {scenarios.map((scenario) => (
@@ -11,11 +11,12 @@ function ScenarioTabs({ label, scenarios, activeScenarioId, onScenarioChange }) 
             key={scenario.id}
             onClick={() => onScenarioChange(scenario.id)}
             className={clsx(
-              'rounded-full border px-4 py-1.5 text-sm transition',
+              'transform rounded-full border px-4 py-1.5 text-sm transition-all duration-300 ease-out hover:-translate-y-0.5 hover:shadow-lg hover:shadow-cyan-500/10 active:scale-95',
               scenario.id === activeScenarioId
                 ? 'border-cyan-400 bg-cyan-500/10 text-cyan-100'
                 : 'border-slate-700 bg-slate-900/70 text-slate-200 hover:border-cyan-400',
             )}
+            title={scenario.description ?? ''}
           >
             {scenario.name}
           </button>

--- a/src/components/ZonesEditor.jsx
+++ b/src/components/ZonesEditor.jsx
@@ -3,19 +3,19 @@ import { PlusIcon, TrashIcon } from '@heroicons/react/24/outline';
 
 function ZonesEditor({ title, zones, onZoneChange, onZoneAdd, onZoneRemove }) {
   return (
-    <section className="space-y-4 rounded-2xl border border-slate-800 bg-slate-900/70 p-4">
+    <section className="space-y-4 rounded-2xl border border-slate-800 bg-slate-900/70 p-4 card-animated">
       <div className="flex items-center justify-between">
         <h2 className="text-lg font-semibold text-slate-100">{title}</h2>
         <button
           onClick={onZoneAdd}
-          className="flex items-center gap-2 rounded-lg border border-cyan-500/40 bg-cyan-500/10 px-3 py-2 text-xs text-cyan-200 hover:bg-cyan-500/20"
+          className="flex items-center gap-2 rounded-lg border border-cyan-500/40 bg-cyan-500/10 px-3 py-2 text-xs text-cyan-200 transition hover:-translate-y-0.5 hover:bg-cyan-500/20 active:scale-95"
         >
           <PlusIcon className="h-4 w-4" /> Добавить зону
         </button>
       </div>
       <div className="space-y-3 text-sm text-slate-200">
         {zones.map((zone) => (
-          <div key={zone.id} className="flex items-center justify-between gap-3 rounded-xl border border-slate-800 bg-slate-950/40 px-3 py-2">
+          <div key={zone.id} className="flex items-center justify-between gap-3 rounded-xl border border-slate-800 bg-slate-950/40 px-3 py-2 card-animated">
             <div className="flex items-center gap-3">
               <span className="h-3 w-3 rounded-full" style={{ backgroundColor: zone.color }} />
               <input
@@ -32,7 +32,7 @@ function ZonesEditor({ title, zones, onZoneChange, onZoneAdd, onZoneRemove }) {
             </div>
             <button
               onClick={() => onZoneRemove(zone.id)}
-              className="rounded-md border border-rose-500/40 bg-rose-500/10 p-2 text-rose-200 hover:bg-rose-500/20"
+              className="transform rounded-md border border-rose-500/40 bg-rose-500/10 p-2 text-rose-200 transition hover:-translate-y-0.5 hover:bg-rose-500/20 active:scale-95"
             >
               <TrashIcon className="h-4 w-4" />
             </button>

--- a/src/data/presets.js
+++ b/src/data/presets.js
@@ -7,6 +7,24 @@ export const defaultZones = [
 
 const note = (text) => text;
 
+const createSalesOnlyScenario = (overrides = {}) => ({
+  id: 'sales-only',
+  name: 'Только продажи',
+  description: 'Маркетинг практически остановлен: продажи тянут выручку за счёт холодных касаний.',
+  adjustments: {},
+  zones: {
+    marketing: { value: -60, conversion: -15 },
+    retention: { value: -25 },
+  },
+  trafficMix: [
+    { id: 'cold-outbound', name: 'Холодные звонки', share: 55, note: 'SDR-каденции, LinkedIn outreach, холодные письма.' },
+    { id: 'email-cadence', name: 'Email nurture', share: 25, note: 'Авто-серии писем вместо маркетинговых кампаний.' },
+    { id: 'field-demos', name: 'Выездные встречи', share: 20, note: 'Демо на стороне клиента, партнёрские интро.' },
+  ],
+  plays: ['Перепрошивка SDR playbook', 'Sales enablement вместо маркетинга'],
+  ...overrides,
+});
+
 export const presets = [
   {
     id: 'b2b-saas',
@@ -255,6 +273,7 @@ export const presets = [
     ],
     scenarios: [
       { id: 'base', name: 'Текущая', adjustments: {} },
+      createSalesOnlyScenario(),
       {
         id: 'improved',
         name: 'Умеренный рост',
@@ -514,6 +533,7 @@ export const presets = [
     ],
     scenarios: [
       { id: 'current', name: 'Текущая', adjustments: {} },
+      createSalesOnlyScenario(),
       {
         id: 'service-up',
         name: 'Опора на сервис',
@@ -643,6 +663,7 @@ export const presets = [
     ],
     scenarios: [
       { id: 'standard', name: 'Текущая', adjustments: {} },
+      createSalesOnlyScenario(),
       {
         id: 'telemed',
         name: 'Телемедицина',
@@ -685,6 +706,7 @@ export const presets = [
     ],
     scenarios: [
       { id: 'default', name: 'База', adjustments: {} },
+      createSalesOnlyScenario(),
       { id: 'promo', name: 'Promo сезон', adjustments: { 'add-to-cart': { conversion: 3 }, paid: { conversion: 2 } } },
       { id: 'retention-boost', name: 'Retention boost', adjustments: { repeat: { conversion: 6 }, reactivation: { conversion: 7 } } },
     ],
@@ -721,6 +743,7 @@ export const presets = [
     ],
     scenarios: [
       { id: 'launch', name: 'Запуск', adjustments: {} },
+      createSalesOnlyScenario(),
       { id: 'evergreen', name: 'Evergreen', adjustments: { warm: { conversion: 5 } } },
       { id: 'animation-push', name: 'Animated push', adjustments: { audience: { value: 18 }, leads: { conversion: 4 }, retention: { conversion: 6 } } },
       { id: 'alumni-enterprise', name: 'Alumni enterprise', adjustments: { alumni: { conversion: 8 }, retention: { conversion: 4 } } },
@@ -756,6 +779,7 @@ export const presets = [
     ],
     scenarios: [
       { id: 'base', name: 'База', adjustments: {} },
+      createSalesOnlyScenario(),
       { id: 'expansion', name: 'Экспансия', adjustments: { leads: { conversion: 5 }, qualification: { conversion: 4 } } },
       { id: 'referral-growth', name: 'Referral growth', adjustments: { loyal: { conversion: 7 } } },
     ],
@@ -792,6 +816,7 @@ export const presets = [
     ],
     scenarios: [
       { id: 'base', name: 'Текущая', adjustments: {} },
+      createSalesOnlyScenario(),
       { id: 'mastermind', name: 'Mastermind рост', adjustments: { vip: { conversion: 8 }, community: { conversion: 5 } } },
       { id: 'productized', name: 'Productized услуги', adjustments: { proposal: { conversion: 6 }, clients: { conversion: 5 } } },
     ],
@@ -828,6 +853,7 @@ export const presets = [
     ],
     scenarios: [
       { id: 'base', name: 'Текущая', adjustments: {} },
+      createSalesOnlyScenario(),
       { id: 'enterprise', name: 'Enterprise push', adjustments: { pilot: { conversion: 6 }, deployment: { conversion: 4 } } },
       { id: 'grant', name: 'Грантовая программа', adjustments: { poc: { conversion: 5 }, retained: { conversion: 5 } } },
     ],
@@ -865,6 +891,7 @@ export const presets = [
     ],
     scenarios: [
       { id: 'steady', name: 'Базовый', adjustments: {} },
+      createSalesOnlyScenario(),
       { id: 'digitization', name: 'Цифровая трансформация', adjustments: { demo: { conversion: 4 }, 'go-live': { conversion: 5 } } },
       { id: 'partner-cosell', name: 'Co-sell с партнёрами', adjustments: { qualified: { conversion: 3 }, expansion: { conversion: 6 } } },
     ],
@@ -890,7 +917,132 @@ export const presets = [
     ],
     scenarios: [
       { id: 'now', name: 'Текущий', adjustments: {} },
+      createSalesOnlyScenario(),
       { id: 'growth', name: 'Рост', adjustments: { subscribers: { conversion: 1 }, proposal: { conversion: 2 } } },
+    ],
+  },
+  {
+    id: 'fintech-payments',
+    name: 'Финтех · платежи B2B',
+    logo: '💳',
+    description: 'Платформа подписок и платежей для SMB. Комбо контента, партнёрств и outbound.',
+    zones: defaultZones,
+    finances: { avgCheck: 3800, cpl: 90, cac: 480, ltv: 18600 },
+    trafficChannels: [
+      { id: 'inbound', name: 'Контент + inbound', share: 28, note: 'Платёжные кейсы, ROI-калькуляторы, SEO.' },
+      { id: 'partners', name: 'Партнёрские интеграции', share: 22, note: 'Бухгалтерские сервисы, ERP, банки.' },
+      { id: 'outbound', name: 'Outbound/ABM', share: 18, note: 'Sales cadences + LinkedIn ads.' },
+      { id: 'events', name: 'Финтех мероприятия', share: 16, note: 'Форумы, закрытые CFO завтраки.' },
+      { id: 'referrals', name: 'Referral & advocacy', share: 16, note: 'Финансовые консультанты, customer advisory board.' },
+    ],
+    stages: [
+      { id: 'research-traffic', name: 'Трафик и лид-магниты', mode: 'absolute', value: 48000, conversion: 100, benchmark: 100, zoneId: 'marketing', note: note('SEO, отчёты по платежам, калькуляторы.'), tasks: [] },
+      { id: 'qualified', name: 'SQL', mode: 'percent', value: 9600, conversion: 20, benchmark: 22, zoneId: 'marketing', note: note('ABM, вебинары для CFO.'), tasks: [] },
+      { id: 'demo', name: 'Демо платформы', mode: 'percent', value: 3840, conversion: 40, benchmark: 42, zoneId: 'sales', note: note('Product demo + платежный аудит.'), tasks: [] },
+      { id: 'pilot', name: 'Пилотный период', mode: 'percent', value: 2304, conversion: 60, benchmark: 58, zoneId: 'sales', note: note('Интеграция с CRM и ERP клиента.'), tasks: [] },
+      { id: 'contracts', name: 'Подписали контракт', mode: 'percent', value: 1267, conversion: 55, benchmark: 52, zoneId: 'sales', note: note('Юр. блок, KYC, тарифы.'), tasks: [] },
+      { id: 'retained', name: 'Активные мерчанты', mode: 'percent', value: 1013, conversion: 80, benchmark: 78, zoneId: 'success', note: note('Поддержка, anti-fraud, SLA.'), tasks: [] },
+      { id: 'expansion', name: 'Расширение чека', mode: 'percent', value: 486, conversion: 48, benchmark: 45, zoneId: 'retention', note: note('Cross-sell модулей, международные платежи.'), tasks: [] },
+    ],
+    levers: [
+      { id: 'roi-calculator', stageId: 'qualified', name: 'ROI-калькулятор', description: 'Персональный расчёт экономики платежей.', conversionBoost: 2.5, tactics: ['Interactive deck', 'Авто-отчёт CFO'] },
+      { id: 'compliance-lab', stageId: 'pilot', name: 'Compliance Lab', description: 'Команда помогает пройти PCI DSS / 54-ФЗ.', conversionBoost: 3.8, tactics: ['Audit checklist', 'Воркшоп по регуляторике'] },
+      { id: 'payments-hub', stageId: 'contracts', name: 'Payments Hub', description: 'Пакет готовых интеграций и API sandbox.', conversionBoost: 4.2, tactics: ['Marketplace интеграций', 'Тех. кабинет для разработчиков'] },
+      { id: 'growth-team', stageId: 'expansion', name: 'Growth squad', description: 'Совместные гипотезы LTV, апсейл новых модулей.', conversionBoost: 5.1, tactics: ['QBR с CFO', 'Геймификация KPI мерчанта'] },
+    ],
+    scenarios: [
+      { id: 'base', name: 'База', adjustments: {} },
+      createSalesOnlyScenario({ description: 'Маркетинг заморожен, работаем через партнёров и SDR.' }),
+      {
+        id: 'accelerate',
+        name: 'Accelerated growth',
+        adjustments: {
+          'research-traffic': { value: 14 },
+          qualified: { conversion: 3 },
+          demo: { conversion: 4 },
+          contracts: { conversion: 3 },
+        },
+      },
+      {
+        id: 'bank-alliances',
+        name: 'Bank alliances',
+        adjustments: {
+          contracts: { conversion: 2 },
+          retained: { conversion: 4 },
+          expansion: { conversion: 5 },
+        },
+        zones: { retention: { conversion: 3 } },
+      },
+    ],
+  },
+  {
+    id: 'mobile-gaming',
+    name: 'Mobile Gaming · F2P',
+    logo: '🕹️',
+    description: 'Free-to-play игра с liveops. Скейлим UA, монетизацию и удержание.',
+    zones: defaultZones,
+    finances: { avgCheck: 28, cpl: 1.8, cac: 3.2, ltv: 62 },
+    trafficChannels: [
+      { id: 'ua', name: 'User Acquisition', share: 38, note: 'Meta Ads, Google App Campaigns, DSP.' },
+      { id: 'aso', name: 'ASO + сторы', share: 16, note: 'ASO, витрины, поисковые кампании.' },
+      { id: 'influencers', name: 'Стримеры и инфлюенсеры', share: 16, note: 'YouTube, Twitch, TikTok интеграции.' },
+      { id: 'community', name: 'Комьюнити и соцсети', share: 15, note: 'Discord, Telegram, ивенты в игре.' },
+      { id: 'cross-promo', name: 'Кросс-промо', share: 15, note: 'Сеть собственных игр и партнёров.' },
+    ],
+    stages: [
+      { id: 'installs', name: 'Установки', mode: 'absolute', value: 520000, conversion: 100, benchmark: 100, zoneId: 'marketing', note: note('UA + органика.'), tasks: [] },
+      { id: 'tutorial', name: 'Прошли туториал', mode: 'percent', value: 353600, conversion: 68, benchmark: 70, zoneId: 'marketing', note: note('Основной drop — скучный onboarding.'), tasks: [] },
+      { id: 'day1', name: 'Retention D1', mode: 'percent', value: 159120, conversion: 45, benchmark: 47, zoneId: 'success', note: note('Liveops события, push коммуникации.'), tasks: [] },
+      { id: 'day7', name: 'Retention D7', mode: 'percent', value: 44553, conversion: 28, benchmark: 30, zoneId: 'success', note: note('Battle pass, события в гильдиях.'), tasks: [] },
+      { id: 'payers', name: 'Плательщики', mode: 'percent', value: 5346, conversion: 12, benchmark: 11, zoneId: 'sales', note: note('IAP офферы и limited-time bundles.'), tasks: [] },
+      { id: 'subscriptions', name: 'Подписки/season pass', mode: 'percent', value: 1871, conversion: 35, benchmark: 32, zoneId: 'retention', note: note('VIP-подписка и liveops бонусы.'), tasks: [] },
+      { id: 'guilds', name: 'Гильдии/сообщество', mode: 'percent', value: 561, conversion: 30, benchmark: 28, zoneId: 'retention', note: note('Социальный граф, PvP события.'), tasks: [] },
+    ],
+    levers: [
+      { id: 'tutorial-rework', stageId: 'tutorial', name: 'Rework туториала', description: 'Интерактивный onboarding и персонализация.', conversionBoost: 4.5, tactics: ['Сегментация UA по каналам', 'Скип кнопка + награды'] },
+      { id: 'liveops-calendar', stageId: 'day7', name: 'LiveOps календарь', description: 'События каждые 3-4 дня с кооперативом.', conversionBoost: 5.2, tactics: ['Сезонные челленджи', 'Guild raid каждые выходные'] },
+      { id: 'monetization-lab', stageId: 'payers', name: 'Монетизационный лаб', description: 'A/B тесты офферов, динамический прайсинг.', conversionBoost: 3.8, tactics: ['Bundle builder', 'Offer personalization по когортам'] },
+      { id: 'vip-program', stageId: 'subscriptions', name: 'VIP программа', description: 'Уровни подписки, эксклюзивные предметы.', conversionBoost: 4.6, tactics: ['Tiered perks', 'Influencer эксклюзивы'] },
+    ],
+    scenarios: [
+      { id: 'base', name: 'База', adjustments: {} },
+      createSalesOnlyScenario({
+        description: 'UA урезан, остаётся органика, кросс-промо и работа комьюнити.',
+        zones: { marketing: { value: -70, conversion: -20 }, retention: { value: -18 } },
+        trafficMix: [
+          { id: 'organic', name: 'ASO + органика', share: 60, note: 'ASO, рекомендации, кросс-промо.' },
+          { id: 'community-only', name: 'Комьюнити', share: 25, note: 'Discord, ивенты, UGC.' },
+          { id: 'influencers-lite', name: 'Инфлюенсеры', share: 15, note: 'Бартерные интеграции и стримы.' },
+        ],
+      }),
+      {
+        id: 'launch-event',
+        name: 'Launch event',
+        adjustments: {
+          installs: { value: 22 },
+          tutorial: { conversion: 5 },
+          payers: { conversion: 2 },
+        },
+      },
+      {
+        id: 'liveops-growth',
+        name: 'LiveOps growth',
+        adjustments: {
+          day1: { conversion: 3 },
+          day7: { conversion: 5 },
+          subscriptions: { conversion: 4 },
+          guilds: { conversion: 5 },
+        },
+        zones: { retention: { conversion: 4 } },
+      },
+      {
+        id: 'monetization-max',
+        name: 'Monetization max',
+        adjustments: {
+          payers: { conversion: 3 },
+          subscriptions: { conversion: 5 },
+        },
+      },
     ],
   },
 ];

--- a/src/index.css
+++ b/src/index.css
@@ -14,3 +14,61 @@ body {
   background: radial-gradient(circle at top, rgba(59, 130, 246, 0.25), transparent 55%),
     radial-gradient(circle at bottom, rgba(16, 185, 129, 0.15), transparent 55%);
 }
+
+.stage-hover {
+  transition: transform 0.55s cubic-bezier(0.22, 1, 0.36, 1),
+    opacity 0.4s ease-out,
+    filter 0.4s ease-out,
+    stroke-width 0.4s ease-out;
+  cursor: pointer;
+}
+
+.stage-hover:hover {
+  transform: translateY(-6px) scale(1.01);
+  filter: drop-shadow(0 16px 32px rgba(56, 189, 248, 0.35));
+  opacity: 1 !important;
+}
+
+.stage-hover:active {
+  transform: translateY(-2px) scale(0.995);
+}
+
+.card-animated {
+  transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1),
+    box-shadow 0.45s ease,
+    border-color 0.45s ease;
+}
+
+.card-animated:hover {
+  transform: translateY(-8px);
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.45);
+  border-color: rgba(103, 232, 249, 0.4);
+}
+
+.pulse-ring {
+  position: relative;
+}
+
+.pulse-ring::after {
+  content: '';
+  position: absolute;
+  inset: -6px;
+  border-radius: 9999px;
+  border: 1px solid rgba(103, 232, 249, 0.25);
+  animation: pulse 2.4s ease-out infinite;
+}
+
+@keyframes pulse {
+  0% {
+    transform: scale(0.95);
+    opacity: 0.65;
+  }
+  60% {
+    transform: scale(1.2);
+    opacity: 0;
+  }
+  100% {
+    transform: scale(1.3);
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Summary
- add scenario summary panel with budget classification, traffic mix, and key plays
- extend scenario logic to support zone adjustments, sales-only mode, and new fintech/mobile gaming presets
- refresh UI with hover/click animations across funnel, cards, and controls

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e0f3652240832085e9c6a7ff6b2d3a