### PR TITLE
Fix budget spend calculation order to prevent runtime crash

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -480,13 +480,13 @@ function App() {
     const marketingLeads = marketingStage?.baseValue ?? 0;
     const improvedMarketingLeads = marketingStage?.improvedValue ?? marketingLeads;
 
-    const budgetShare = scenarioMeta.shareOfRevenue ?? null;
-    const spendBase = budgetShare != null ? revenueBase * budgetShare : marketingLeads * (state.finances.cpl ?? 0);
-    const spendImproved = budgetShare != null ? revenueImproved * budgetShare : improvedMarketingLeads * (state.finances.cpl ?? 0);
     const dealsBase = finalBase;
     const dealsImproved = finalImproved;
     const revenueBase = dealsBase * (state.finances.avgCheck ?? 0);
     const revenueImproved = dealsImproved * (state.finances.avgCheck ?? 0);
+    const budgetShare = scenarioMeta.shareOfRevenue ?? null;
+    const spendBase = budgetShare != null ? revenueBase * budgetShare : marketingLeads * (state.finances.cpl ?? 0);
+    const spendImproved = budgetShare != null ? revenueImproved * budgetShare : improvedMarketingLeads * (state.finances.cpl ?? 0);
     const cac = state.finances.cac ?? 0;
     const ltv = state.finances.ltv ?? 0;
     const grossMarginBase = revenueBase - spendBase - dealsBase * cac;


### PR DESCRIPTION
## Summary
- reorder the revenue and spend calculations so values are defined before they are used

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3d6f5e7c08320b38150b56d193444