### PR TITLE
Add blank workspace preset and stage traffic channel editing

### DIFF
--- a/src/components/Editor.jsx
+++ b/src/components/Editor.jsx
@@ -14,6 +14,7 @@ function StageCard({ stage, zones, onStageChange, onStageRemove, onNoteChange, o
   const numberFormatter = useMemo(() => createFormatter(locale), [locale]);
   const zoneOptions = zones ?? [];
   const isPercentMode = stage.mode !== 'absolute';
+  const trafficChannels = stage.trafficChannels ?? [];
 
   const handleValueChange = (value) => {
     const numeric = Number(value);
@@ -46,6 +47,24 @@ function StageCard({ stage, zones, onStageChange, onStageRemove, onNoteChange, o
       const absoluteValue = stage.baseValue ?? stage.value;
       onStageChange(stage.id, { mode: 'absolute', value: absoluteValue });
     }
+  };
+
+  const handleTrafficChannelChange = (channelId, patch) => {
+    const next = trafficChannels.map((channel) => (channel.id === channelId ? { ...channel, ...patch } : channel));
+    onStageChange(stage.id, { trafficChannels: next });
+  };
+
+  const handleTrafficChannelAdd = () => {
+    const id = `${stage.id}-traffic-${Date.now()}`;
+    onStageChange(stage.id, {
+      trafficChannels: [...trafficChannels, { id, name: '', share: 0, note: '' }],
+    });
+  };
+
+  const handleTrafficChannelRemove = (channelId) => {
+    onStageChange(stage.id, {
+      trafficChannels: trafficChannels.filter((channel) => channel.id !== channelId),
+    });
   };
 
   return (
@@ -121,6 +140,63 @@ function StageCard({ stage, zones, onStageChange, onStageRemove, onNoteChange, o
               className="min-h-[80px] rounded-lg border border-slate-700 bg-slate-950/70 px-3 py-2 text-sm"
             />
           </label>
+          <div className="rounded-2xl border border-slate-800 bg-slate-950/70 p-3">
+            <div className="mb-3 flex items-center justify-between">
+              <span className="text-xs uppercase tracking-wide text-slate-400">Каналы трафика этапа</span>
+              <button
+                onClick={handleTrafficChannelAdd}
+                className="flex items-center gap-1 rounded-md border border-emerald-500/40 bg-emerald-500/10 px-2 py-1 text-xs text-emerald-200 transition hover:-translate-y-0.5 hover:bg-emerald-500/20 active:scale-95"
+              >
+                <PlusIcon className="h-3.5 w-3.5" /> Канал
+              </button>
+            </div>
+            {trafficChannels.length ? (
+              <div className="space-y-3">
+                {trafficChannels.map((channel) => (
+                  <div key={channel.id} className="space-y-2 rounded-xl border border-slate-800 bg-slate-900/60 p-3">
+                    <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
+                      <input
+                        value={channel.name ?? ''}
+                        onChange={(event) => handleTrafficChannelChange(channel.id, { name: event.target.value })}
+                        placeholder="Название канала"
+                        className="flex-1 rounded-lg border border-slate-700 bg-slate-950/70 px-3 py-2 text-sm text-slate-100 focus:border-cyan-400 focus:outline-none"
+                      />
+                      <div className="flex items-center gap-2">
+                        <input
+                          type="number"
+                          value={channel.share ?? 0}
+                          onChange={(event) => {
+                            const numeric = Number(event.target.value);
+                            handleTrafficChannelChange(channel.id, {
+                              share: Number.isFinite(numeric) ? numeric : 0,
+                            });
+                          }}
+                          className="w-20 rounded-lg border border-slate-700 bg-slate-950/70 px-3 py-2 text-sm"
+                        />
+                        <span className="text-xs text-slate-500">%</span>
+                      </div>
+                      <button
+                        onClick={() => handleTrafficChannelRemove(channel.id)}
+                        className="self-start rounded-lg border border-rose-600/40 bg-rose-500/10 p-2 text-rose-200 transition hover:-translate-y-0.5 hover:bg-rose-500/20 active:scale-95"
+                        title="Удалить канал"
+                      >
+                        <TrashIcon className="h-4 w-4" />
+                      </button>
+                    </div>
+                    <textarea
+                      value={channel.note ?? ''}
+                      onChange={(event) => handleTrafficChannelChange(channel.id, { note: event.target.value })}
+                      placeholder="Комментарий, подсказки, CTA"
+                      className="w-full rounded-lg border border-slate-700 bg-slate-950/70 px-3 py-2 text-sm text-slate-200 focus:border-cyan-400 focus:outline-none"
+                      rows={2}
+                    />
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="text-xs text-slate-500">Добавьте источники трафика для этого этапа.</p>
+            )}
+          </div>
         </div>
         <button
           onClick={() => onStageRemove(stage.id)}

--- a/src/data/presets.js
+++ b/src/data/presets.js
@@ -27,6 +27,29 @@ const createSalesOnlyScenario = (overrides = {}) => ({
 
 export const presets = [
   {
+    id: 'custom',
+    name: 'Своя карточка',
+    locale: 'ru',
+    logo: '🆕',
+    description:
+      'Пустой шаблон: добавьте компанию, продукт и этапы воронки с нуля.',
+    zones: defaultZones,
+    finances: { avgCheck: 0, cpl: 0, cac: 0, ltv: 0 },
+    trafficChannels: [],
+    stages: [],
+    scenarios: [
+      {
+        id: 'base',
+        name: 'Base',
+        description: 'Стартовый сценарий для своей компании.',
+        adjustments: {},
+        plays: [],
+      },
+    ],
+    levers: [],
+    stakeholders: [],
+  },
+  {
     id: 'b2b-saas',
     name: 'B2B SaaS · AARRR',
     locale: 'ru',
@@ -154,6 +177,11 @@ export const presets = [
         tasks: [
           { id: 'awareness-1', text: 'Провести рекламный вебинар по кейсам клиентов', done: false },
         ],
+        trafficChannels: [
+          { id: 'awareness-seo', name: 'Контент + SEO', share: 38, note: 'Лонгриды, партнерские гайды, guest-посты.' },
+          { id: 'awareness-paid', name: 'Paid Social', share: 34, note: 'LinkedIn, Facebook, ретаргет.' },
+          { id: 'awareness-events', name: 'Комьюнити и ивенты', share: 28, note: 'Встречи клиентов, product meetup, AMA.' },
+        ],
       },
       {
         id: 'acquisition',
@@ -166,6 +194,11 @@ export const presets = [
         note: note('Основные источники: контент-маркетинг, ретаргетинг.'),
         tasks: [
           { id: 'acq-1', text: 'Обновить лид-магниты и триггерные письма', done: false },
+        ],
+        trafficChannels: [
+          { id: 'acquisition-product', name: 'Product tours', share: 42, note: 'Интерактивный product tour на сайте.' },
+          { id: 'acquisition-ads', name: 'Performance', share: 35, note: 'Paid search, intent кампании.' },
+          { id: 'acquisition-affiliates', name: 'Партнёры', share: 23, note: 'Joint вебинары и кросс-рассылки.' },
         ],
       },
       {
@@ -180,6 +213,11 @@ export const presets = [
         tasks: [
           { id: 'act-1', text: 'Добавить product tour в мобильном приложении', done: true },
         ],
+        trafficChannels: [
+          { id: 'activation-onboarding', name: 'Онбординг-автоцепочки', share: 55, note: 'Trigger email + in-app тултип.' },
+          { id: 'activation-csm', name: 'CSM calls', share: 28, note: 'Онбординг-звонки на 14 и 28 день.' },
+          { id: 'activation-academy', name: 'Customer academy', share: 17, note: 'Видеоуроки и воркшопы.' },
+        ],
       },
       {
         id: 'revenue',
@@ -192,6 +230,11 @@ export const presets = [
         note: note('Основной план: годовые подписки через менеджеров.'),
         tasks: [
           { id: 'rev-1', text: 'Настроить e-mail цепочку с кейсами ROI', done: false },
+        ],
+        trafficChannels: [
+          { id: 'revenue-sdr', name: 'SDR', share: 46, note: 'Дожим демо и discovery calls.' },
+          { id: 'revenue-upsell', name: 'Upsell nurture', share: 33, note: 'Продуктовые цепочки и ROI кейсы.' },
+          { id: 'revenue-partners', name: 'Партнёрские сделки', share: 21, note: 'GSIs и консалтинговые партнёры.' },
         ],
       },
       {
@@ -206,6 +249,11 @@ export const presets = [
         tasks: [
           { id: 'ref-1', text: 'Запустить бонусные кредиты за отзывы', done: false },
         ],
+        trafficChannels: [
+          { id: 'referral-advocacy', name: 'Advocacy club', share: 48, note: 'Кейсы и рекомендации от power users.' },
+          { id: 'referral-rewards', name: 'Referral rewards', share: 32, note: 'Бонусные кредиты и подарки.' },
+          { id: 'referral-community', name: 'Community', share: 20, note: 'AMA, Slack, закрытые митапы.' },
+        ],
       },
       {
         id: 'expansion',
@@ -218,6 +266,11 @@ export const presets = [
         note: note('QBR, продуктовая карта, консультации по внедрению новых модулей.'),
         tasks: [
           { id: 'exp-1', text: 'Внедрить ежеквартальные value-review сессии', done: false },
+        ],
+        trafficChannels: [
+          { id: 'expansion-qbr', name: 'QBR', share: 44, note: 'Value review и roadmap alignment.' },
+          { id: 'expansion-customer-marketing', name: 'Customer marketing', share: 31, note: 'ABM письма и ROI-кейсы.' },
+          { id: 'expansion-partners', name: 'Success partners', share: 25, note: 'Партнёры по внедрению.' },
         ],
       },
     ],


### PR DESCRIPTION
## Summary
- add an empty "Своя карточка" preset so the app opens on a blank funnel by default and normalize imported data
- allow editing workspace name/logo/description, quick reset to a new card, and include language in JSON export/import
- extend the stage editor with per-stage traffic channels and seed a preset with sample data for the new fields

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ee76d2dd548320b9a10ead508ad20b