### PR TITLE
Add funnel comparison view and shared funnel utilities

### DIFF
--- a/src/components/FunnelComparison.jsx
+++ b/src/components/FunnelComparison.jsx
@@ -1,0 +1,507 @@
+import { useMemo, useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { ArrowUpTrayIcon } from '@heroicons/react/24/outline';
+import {
+  calculateMetrics,
+  fallbackScenario,
+  getScenarioMeta,
+  normalizeState,
+} from '../utils/funnel.js';
+
+function pickWinner(leftValue, rightValue, { lowerIsBetter = false, tolerance = 0.05 } = {}) {
+  const left = typeof leftValue === 'number' ? leftValue : null;
+  const right = typeof rightValue === 'number' ? rightValue : null;
+  if (left == null && right == null) return 'tie';
+  if (left == null) return 'right';
+  if (right == null) return 'left';
+  const diff = left - right;
+  const scale = Math.max(Math.abs(left), Math.abs(right), 1);
+  if (Math.abs(diff) <= scale * tolerance) {
+    return 'tie';
+  }
+  if (lowerIsBetter) {
+    return left < right ? 'left' : 'right';
+  }
+  return left > right ? 'left' : 'right';
+}
+
+function evaluateFunnel(funnel) {
+  if (!funnel) return null;
+  const { state, metrics } = funnel;
+  const stages = state.stages ?? [];
+  const tasksCount = stages.reduce((sum, stage) => sum + (stage.tasks?.length ?? 0), 0);
+  const leversCount = state.levers?.length ?? 0;
+  const stagesCount = stages.length;
+  const complexity = stagesCount + leversCount * 1.6 + tasksCount * 0.25;
+  const cost = metrics.spendImproved ?? metrics.spendBase ?? 0;
+  const budgetShare = metrics.marketingBudgetShare ?? 0;
+  const result = metrics.revenueImproved ?? 0;
+  const deltaPercent = metrics.deltaPercent ?? 0;
+  const speed = metrics.paybackMonths ?? 0;
+  const roi = metrics.roiImproved ?? 0;
+  const churn = metrics.churnRateImproved ?? metrics.churnRate ?? 0;
+  const playsCount = metrics.scenarioPlays?.length ?? 0;
+  const confidence = Math.max(1, Math.min(10, 5 + roi / 40 + playsCount * 0.5 - churn / 25));
+  return {
+    label: funnel.label,
+    scenarioName: funnel.scenario?.name ?? '',
+    stagesCount,
+    leversCount,
+    tasksCount,
+    complexity,
+    cost,
+    budgetShare,
+    result,
+    deltaPercent,
+    speed,
+    roi,
+    churn,
+    confidence,
+    metrics,
+  };
+}
+
+function buildSummary(left, right, formatters, strings) {
+  if (!left || !right) return [];
+  const items = [
+    {
+      id: 'cost',
+      label: strings.summaryCost,
+      winner: pickWinner(left.cost, right.cost, { lowerIsBetter: true, tolerance: 0.07 }),
+      leftText: `${formatters.money(left.cost)} · ${formatters.share(left.budgetShare)}`,
+      rightText: `${formatters.money(right.cost)} · ${formatters.share(right.budgetShare)}`,
+    },
+    {
+      id: 'ease',
+      label: strings.summaryEase,
+      winner: pickWinner(left.complexity, right.complexity, { lowerIsBetter: true, tolerance: 0.08 }),
+      leftText: `${strings.complexityLabel}: ${formatters.index(left.complexity)} · ${strings.statsStages}: ${left.stagesCount}`,
+      rightText: `${strings.complexityLabel}: ${formatters.index(right.complexity)} · ${strings.statsStages}: ${right.stagesCount}`,
+    },
+    {
+      id: 'result',
+      label: strings.summaryResult,
+      winner: pickWinner(left.result, right.result, { lowerIsBetter: false, tolerance: 0.05 }),
+      leftText: `${formatters.money(left.result)} · Δ ${formatters.percentValue(left.deltaPercent)}`,
+      rightText: `${formatters.money(right.result)} · Δ ${formatters.percentValue(right.deltaPercent)}`,
+    },
+    {
+      id: 'speed',
+      label: strings.summarySpeed,
+      winner: pickWinner(left.speed, right.speed, { lowerIsBetter: true, tolerance: 0.1 }),
+      leftText: formatters.months(left.speed),
+      rightText: formatters.months(right.speed),
+    },
+    {
+      id: 'confidence',
+      label: strings.summaryConfidence,
+      winner: pickWinner(left.confidence, right.confidence, { lowerIsBetter: false, tolerance: 0.05 }),
+      leftText: `${strings.confidenceLabel}: ${formatters.index(left.confidence)}${strings.confidenceUnit}`,
+      rightText: `${strings.confidenceLabel}: ${formatters.index(right.confidence)}${strings.confidenceUnit}`,
+    },
+  ];
+
+  return items.map((item) => {
+    if (item.winner === 'tie') {
+      return { ...item, description: strings.summaryTie };
+    }
+    const winnerLabel = item.winner === 'left' ? left.label : right.label;
+    const loserLabel = item.winner === 'left' ? right.label : left.label;
+    const winnerValue = item.winner === 'left' ? item.leftText : item.rightText;
+    const loserValue = item.winner === 'left' ? item.rightText : item.leftText;
+    return {
+      ...item,
+      description: `${winnerLabel} ${strings.winnerPrefix} • ${winnerValue} ${strings.versus} ${loserLabel}: ${loserValue}`,
+    };
+  });
+}
+
+function FunnelComparison({ presets, currentState, locale, strings, onExit }) {
+  const safeLocale = locale ?? 'ru-RU';
+
+  const numberFormatter = useMemo(() => {
+    try {
+      return new Intl.NumberFormat(safeLocale, { maximumFractionDigits: 0 });
+    } catch (error) {
+      return new Intl.NumberFormat('ru-RU', { maximumFractionDigits: 0 });
+    }
+  }, [safeLocale]);
+
+  const decimalFormatter = useMemo(() => {
+    try {
+      return new Intl.NumberFormat(safeLocale, { maximumFractionDigits: 1 });
+    } catch (error) {
+      return new Intl.NumberFormat('ru-RU', { maximumFractionDigits: 1 });
+    }
+  }, [safeLocale]);
+
+  const percentFormatter = useMemo(() => {
+    try {
+      return new Intl.NumberFormat(safeLocale, { style: 'percent', maximumFractionDigits: 1 });
+    } catch (error) {
+      return new Intl.NumberFormat('ru-RU', { style: 'percent', maximumFractionDigits: 1 });
+    }
+  }, [safeLocale]);
+
+  const insightFormatter = useMemo(() => {
+    try {
+      return new Intl.NumberFormat(safeLocale, { maximumFractionDigits: 1 });
+    } catch (error) {
+      return new Intl.NumberFormat('ru-RU', { maximumFractionDigits: 1 });
+    }
+  }, [safeLocale]);
+
+  const formatters = useMemo(
+    () => ({
+      money: (value) => `${numberFormatter.format(Math.round(value ?? 0))}${strings.currencySuffix ? ` ${strings.currencySuffix}` : ''}`,
+      share: (value) => percentFormatter.format(Math.max(0, value ?? 0)),
+      percentValue: (value) => `${decimalFormatter.format(value ?? 0)}%`,
+      months: (value) => (value != null && value <= 0.2 ? strings.immediate : `${decimalFormatter.format(Math.max(0, value ?? 0))} ${strings.monthShort}`),
+      index: (value) => decimalFormatter.format(Math.max(0, value ?? 0)),
+    }),
+    [decimalFormatter, numberFormatter, percentFormatter, strings.currencySuffix, strings.immediate, strings.monthShort],
+  );
+
+  const buildFunnel = (raw, label, source) => {
+    if (!raw) return null;
+    try {
+      const normalized = normalizeState(raw);
+      const scenario = normalized.scenarios?.[0] ?? fallbackScenario;
+      const meta = getScenarioMeta(scenario, normalized.trafficChannels);
+      const metrics = calculateMetrics({
+        state: normalized,
+        scenario,
+        scenarioMeta: meta,
+        activeLevers: new Set(),
+        numberFormatter: insightFormatter,
+      });
+      return {
+        label: label && label.trim() ? label : normalized.name || strings.unknownName,
+        state: normalized,
+        scenario,
+        scenarioMeta: meta,
+        metrics,
+        source,
+      };
+    } catch (error) {
+      console.error('Failed to build funnel for comparison', error);
+      return null;
+    }
+  };
+
+  const [leftFunnel, setLeftFunnel] = useState(() => buildFunnel(currentState, strings.currentFunnelLabel, 'current'));
+  const [rightFunnel, setRightFunnel] = useState(null);
+  const [leftPresetId, setLeftPresetId] = useState('');
+  const [rightPresetId, setRightPresetId] = useState('');
+  const [leftError, setLeftError] = useState(null);
+  const [rightError, setRightError] = useState(null);
+
+  useEffect(() => {
+    setLeftFunnel((prev) => (prev ? buildFunnel(prev.state, prev.label, prev.source) : prev));
+    setRightFunnel((prev) => (prev ? buildFunnel(prev.state, prev.label, prev.source) : prev));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [insightFormatter]);
+
+  const handlePresetChange = (side, presetId) => {
+    const preset = presets.find((item) => item.id === presetId);
+    if (!preset) {
+      if (side === 'left') {
+        setLeftPresetId('');
+      } else {
+        setRightPresetId('');
+      }
+      return;
+    }
+    const funnel = buildFunnel(preset, preset.name, 'preset');
+    if (side === 'left') {
+      setLeftPresetId(presetId);
+      setLeftFunnel(funnel);
+      setLeftError(null);
+    } else {
+      setRightPresetId(presetId);
+      setRightFunnel(funnel);
+      setRightError(null);
+    }
+  };
+
+  const handleUseCurrent = (side) => {
+    const funnel = buildFunnel(currentState, strings.currentFunnelLabel, 'current');
+    if (side === 'left') {
+      setLeftFunnel(funnel);
+      setLeftPresetId('');
+      setLeftError(null);
+    } else {
+      setRightFunnel(funnel);
+      setRightPresetId('');
+      setRightError(null);
+    }
+  };
+
+  const handleFileImport = (side, file) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      try {
+        const parsed = JSON.parse(reader.result ?? '{}');
+        const funnel = buildFunnel(parsed, file.name.replace(/\.json$/i, ''), 'file');
+        if (!funnel) {
+          throw new Error('invalid funnel');
+        }
+        if (side === 'left') {
+          setLeftFunnel(funnel);
+          setLeftPresetId('');
+          setLeftError(null);
+        } else {
+          setRightFunnel(funnel);
+          setRightPresetId('');
+          setRightError(null);
+        }
+      } catch (error) {
+        if (side === 'left') {
+          setLeftError(strings.fileError);
+        } else {
+          setRightError(strings.fileError);
+        }
+      }
+    };
+    reader.onerror = () => {
+      if (side === 'left') {
+        setLeftError(strings.fileError);
+      } else {
+        setRightError(strings.fileError);
+      }
+    };
+    reader.readAsText(file);
+  };
+
+  const leftEval = useMemo(() => evaluateFunnel(leftFunnel), [leftFunnel]);
+  const rightEval = useMemo(() => evaluateFunnel(rightFunnel), [rightFunnel]);
+  const summaryItems = useMemo(() => buildSummary(leftEval, rightEval, formatters, strings), [leftEval, rightEval, formatters, strings]);
+
+  const renderSelector = (side, funnel, presetId, setPresetId, error, onSelect, onUse, onImport) => (
+    <div className="card-animated rounded-3xl border border-slate-800 bg-slate-900/50 p-6 shadow-lg shadow-slate-950/40">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h3 className="text-lg font-semibold text-slate-100">{side === 'left' ? strings.leftLabel : strings.rightLabel}</h3>
+          <p className="text-sm text-slate-400">{funnel?.label ?? strings.unknownName}</p>
+        </div>
+        <button
+          type="button"
+          onClick={() => onUse(side)}
+          className="rounded-md border border-emerald-500/40 bg-emerald-500/10 px-3 py-2 text-xs font-medium text-emerald-200 hover:bg-emerald-500/20"
+        >
+          {strings.useCurrent}
+        </button>
+      </div>
+      <div className="mt-4 space-y-3 text-sm">
+        <label className="flex flex-col gap-1">
+          <span className="text-slate-300">{strings.selectPreset}</span>
+          <select
+            value={presetId}
+            onChange={(event) => {
+              const value = event.target.value;
+              setPresetId(value);
+              onSelect(side, value);
+            }}
+            className="rounded-md border border-slate-700 bg-slate-900 px-3 py-2"
+          >
+            <option value="">{strings.selectPresetPlaceholder}</option>
+            {presets.map((preset) => (
+              <option key={`${side}-${preset.id}`} value={preset.id}>
+                {preset.logo ?? '•'} {preset.name}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex cursor-pointer items-center justify-between gap-3 rounded-md border border-slate-700/80 bg-slate-900 px-3 py-2 text-xs text-slate-200">
+          <span className="flex items-center gap-2">
+            <ArrowUpTrayIcon className="h-4 w-4" /> {strings.importLabel}
+          </span>
+          <input
+            type="file"
+            accept=".json"
+            className="hidden"
+            onChange={(event) => {
+              const file = event.target.files?.[0];
+              if (file) {
+                onImport(side, file);
+                event.target.value = '';
+              }
+            }}
+          />
+        </label>
+        {error ? <p className="text-xs text-rose-400">{error}</p> : null}
+        {funnel ? (
+          <dl className="grid grid-cols-2 gap-2 text-xs text-slate-300">
+            <div>
+              <dt className="text-slate-500">{strings.statsStages}</dt>
+              <dd className="font-medium text-slate-100">{funnel.state.stages?.length ?? 0}</dd>
+            </div>
+            <div>
+              <dt className="text-slate-500">{strings.statsLevers}</dt>
+              <dd className="font-medium text-slate-100">{funnel.state.levers?.length ?? 0}</dd>
+            </div>
+          </dl>
+        ) : null}
+      </div>
+    </div>
+  );
+
+  const renderStatsCard = (evalData) => (
+    <div className="rounded-3xl border border-slate-800 bg-slate-900/40 p-6 shadow shadow-slate-950/40">
+      <div className="flex flex-col gap-1">
+        <h4 className="text-lg font-semibold text-slate-100">{evalData.label}</h4>
+        {evalData.scenarioName ? (
+          <p className="text-xs text-slate-400">{evalData.scenarioName}</p>
+        ) : null}
+      </div>
+      <dl className="mt-4 grid grid-cols-2 gap-3 text-sm text-slate-300">
+        <div>
+          <dt className="text-slate-500">{strings.statsStages}</dt>
+          <dd className="font-medium text-slate-100">{evalData.stagesCount}</dd>
+        </div>
+        <div>
+          <dt className="text-slate-500">{strings.statsLevers}</dt>
+          <dd className="font-medium text-slate-100">{evalData.leversCount}</dd>
+        </div>
+        <div>
+          <dt className="text-slate-500">{strings.statsTasks}</dt>
+          <dd className="font-medium text-slate-100">{evalData.tasksCount}</dd>
+        </div>
+        <div>
+          <dt className="text-slate-500">{strings.complexityLabel}</dt>
+          <dd className="font-medium text-slate-100">{formatters.index(evalData.complexity)}</dd>
+        </div>
+        <div>
+          <dt className="text-slate-500">{strings.statsBudgetShare}</dt>
+          <dd className="font-medium text-slate-100">{formatters.share(evalData.budgetShare)}</dd>
+        </div>
+        <div>
+          <dt className="text-slate-500">{strings.statsSpend}</dt>
+          <dd className="font-medium text-slate-100">{formatters.money(evalData.metrics.spendImproved ?? evalData.metrics.spendBase)}</dd>
+        </div>
+        <div>
+          <dt className="text-slate-500">{strings.statsROI}</dt>
+          <dd className="font-medium text-slate-100">{formatters.percentValue(evalData.roi)}</dd>
+        </div>
+        <div>
+          <dt className="text-slate-500">{strings.statsPayback}</dt>
+          <dd className="font-medium text-slate-100">{formatters.months(evalData.speed)}</dd>
+        </div>
+        <div>
+          <dt className="text-slate-500">{strings.statsRevenue}</dt>
+          <dd className="font-medium text-slate-100">{formatters.money(evalData.result)}</dd>
+        </div>
+        <div>
+          <dt className="text-slate-500">{strings.confidenceLabel}</dt>
+          <dd className="font-medium text-slate-100">{`${formatters.index(evalData.confidence)}${strings.confidenceUnit}`}</dd>
+        </div>
+      </dl>
+    </div>
+  );
+
+  return (
+    <section className="mt-6 space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h2 className="text-2xl font-semibold text-slate-100">{strings.title}</h2>
+          <p className="text-sm text-slate-400">{strings.subtitle}</p>
+        </div>
+        <button
+          type="button"
+          onClick={onExit}
+          className="rounded-md border border-cyan-500/40 bg-cyan-500/10 px-4 py-2 text-sm font-medium text-cyan-200 transition hover:bg-cyan-500/20"
+        >
+          {strings.backToBuilder}
+        </button>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        {renderSelector('left', leftFunnel, leftPresetId, setLeftPresetId, leftError, handlePresetChange, handleUseCurrent, handleFileImport)}
+        {renderSelector('right', rightFunnel, rightPresetId, setRightPresetId, rightError, handlePresetChange, handleUseCurrent, handleFileImport)}
+      </div>
+
+      <div className="rounded-3xl border border-slate-800 bg-slate-900/40 p-6 shadow shadow-slate-950/40">
+        <h3 className="text-lg font-semibold text-slate-100">{strings.summaryTitle}</h3>
+        {summaryItems.length ? (
+          <ul className="mt-4 space-y-3 text-sm text-slate-300">
+            {summaryItems.map((item) => (
+              <li key={item.id} className="rounded-2xl border border-slate-800/60 bg-slate-900/40 p-4">
+                <div className="flex flex-wrap items-center justify-between gap-2 text-slate-200">
+                  <span className="text-sm font-medium text-slate-100">{item.label}</span>
+                  <span className="text-xs text-slate-400">{item.winner === 'tie' ? '≈' : item.winner === 'left' ? strings.leftLabel : strings.rightLabel}</span>
+                </div>
+                <p className="mt-2 text-xs text-slate-300">{item.description}</p>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="mt-4 text-sm text-slate-400">{strings.missingData}</p>
+        )}
+      </div>
+
+      <div className="space-y-4">
+        <h3 className="text-lg font-semibold text-slate-100">{strings.statsTitle}</h3>
+        <div className="grid gap-6 lg:grid-cols-2">
+          {leftEval ? renderStatsCard(leftEval) : null}
+          {rightEval ? renderStatsCard(rightEval) : null}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+FunnelComparison.propTypes = {
+  presets: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired,
+    logo: PropTypes.string,
+  })).isRequired,
+  currentState: PropTypes.object.isRequired,
+  locale: PropTypes.string,
+  strings: PropTypes.shape({
+    title: PropTypes.string.isRequired,
+    subtitle: PropTypes.string.isRequired,
+    backToBuilder: PropTypes.string.isRequired,
+    leftLabel: PropTypes.string.isRequired,
+    rightLabel: PropTypes.string.isRequired,
+    selectPreset: PropTypes.string.isRequired,
+    selectPresetPlaceholder: PropTypes.string.isRequired,
+    useCurrent: PropTypes.string.isRequired,
+    importLabel: PropTypes.string.isRequired,
+    summaryTitle: PropTypes.string.isRequired,
+    missingData: PropTypes.string.isRequired,
+    summaryCost: PropTypes.string.isRequired,
+    summaryEase: PropTypes.string.isRequired,
+    summaryResult: PropTypes.string.isRequired,
+    summarySpeed: PropTypes.string.isRequired,
+    summaryConfidence: PropTypes.string.isRequired,
+    summaryTie: PropTypes.string.isRequired,
+    winnerPrefix: PropTypes.string.isRequired,
+    versus: PropTypes.string.isRequired,
+    currencySuffix: PropTypes.string,
+    monthShort: PropTypes.string.isRequired,
+    immediate: PropTypes.string.isRequired,
+    confidenceLabel: PropTypes.string.isRequired,
+    confidenceUnit: PropTypes.string.isRequired,
+    statsTitle: PropTypes.string.isRequired,
+    statsStages: PropTypes.string.isRequired,
+    statsLevers: PropTypes.string.isRequired,
+    statsTasks: PropTypes.string.isRequired,
+    statsBudgetShare: PropTypes.string.isRequired,
+    statsSpend: PropTypes.string.isRequired,
+    statsROI: PropTypes.string.isRequired,
+    statsPayback: PropTypes.string.isRequired,
+    statsRevenue: PropTypes.string.isRequired,
+    currentFunnelLabel: PropTypes.string.isRequired,
+    unknownName: PropTypes.string.isRequired,
+    fileError: PropTypes.string.isRequired,
+    complexityLabel: PropTypes.string.isRequired,
+  }).isRequired,
+  onExit: PropTypes.func.isRequired,
+};
+
+FunnelComparison.defaultProps = {
+  locale: 'ru-RU',
+};
+
+export default FunnelComparison;

--- a/src/utils/funnel.js
+++ b/src/utils/funnel.js
@@ -1,0 +1,496 @@
+import { defaultZones } from '../data/presets.js';
+
+export function deepClone(value) {
+  if (typeof structuredClone === 'function') {
+    return structuredClone(value);
+  }
+  return JSON.parse(JSON.stringify(value ?? {}));
+}
+
+export const fallbackScenario = { id: 'base', name: 'Base', adjustments: {} };
+
+export function normalizeTrafficChannel(channel, index, prefix = 'traffic') {
+  const numericShare = Number(channel?.share);
+  return {
+    id: channel?.id ?? `${prefix}-${index}`,
+    name: channel?.name ?? '',
+    share: Number.isFinite(numericShare) ? numericShare : 0,
+    note: channel?.note ?? '',
+  };
+}
+
+export function normalizeStage(stage, index) {
+  const id = stage?.id ?? `stage-${index}`;
+  const numericValue = Number(stage?.value);
+  const numericConversion = Number(stage?.conversion);
+  const numericBenchmark = Number(stage?.benchmark);
+  const mode = stage?.mode === 'absolute' ? 'absolute' : 'percent';
+  return {
+    id,
+    name: stage?.name ?? `Stage ${index + 1}`,
+    mode,
+    value: Number.isFinite(numericValue) ? numericValue : 0,
+    conversion:
+      mode === 'absolute'
+        ? Number.isFinite(numericConversion)
+          ? numericConversion
+          : 100
+        : Number.isFinite(numericConversion)
+          ? numericConversion
+          : 0,
+    benchmark: Number.isFinite(numericBenchmark) ? numericBenchmark : null,
+    zoneId: stage?.zoneId ?? 'marketing',
+    note: stage?.note ?? '',
+    tasks: (stage?.tasks ?? []).map((task, taskIndex) => ({
+      id: task?.id ?? `${id}-task-${taskIndex}`,
+      text: task?.text ?? '',
+      done: Boolean(task?.done),
+    })),
+    trafficChannels: (stage?.trafficChannels ?? []).map((channel, channelIndex) =>
+      normalizeTrafficChannel(channel, channelIndex, `${id}-traffic`),
+    ),
+  };
+}
+
+export function normalizeState(input, zonesFallback = defaultZones) {
+  const clone = deepClone(input ?? {});
+  const zones = clone.zones?.length ? clone.zones : deepClone(zonesFallback);
+  const finances = clone.finances ?? {};
+  const parseNumeric = (value) => {
+    const numeric = Number(value);
+    return Number.isFinite(numeric) ? numeric : 0;
+  };
+  return {
+    id: clone.id ?? 'custom',
+    name: clone.name ?? '',
+    description: clone.description ?? '',
+    logo: clone.logo ?? '📈',
+    stages: (clone.stages ?? []).map((stage, index) => normalizeStage(stage, index)),
+    zones: zones.map((zone, index) => ({
+      id: zone.id ?? `zone-${index}`,
+      name: zone.name ?? `Zone ${index + 1}`,
+      color: zone.color ?? '#1d4ed8',
+    })),
+    levers: (clone.levers ?? []).map((lever, index) => ({
+      ...lever,
+      id: lever.id ?? `lever-${index}`,
+    })),
+    finances: {
+      avgCheck: parseNumeric(finances.avgCheck),
+      cpl: parseNumeric(finances.cpl),
+      cac: parseNumeric(finances.cac),
+      ltv: parseNumeric(finances.ltv),
+    },
+    scenarios: (clone.scenarios?.length ? clone.scenarios : [fallbackScenario]).map((scenario, index) => ({
+      ...scenario,
+      id: scenario.id ?? `scenario-${index}`,
+      name: scenario.name ?? `Scenario ${index + 1}`,
+      adjustments: scenario.adjustments ?? {},
+      zones: scenario.zones ?? {},
+      plays: scenario.plays ?? [],
+    })),
+    trafficChannels: (clone.trafficChannels ?? []).map((channel, index) => normalizeTrafficChannel(channel, index)),
+    stakeholders: clone.stakeholders ?? [],
+    locale: clone.locale,
+  };
+}
+
+export function loadPreset(preset) {
+  return normalizeState(preset);
+}
+
+export function normalizeShares(channels) {
+  if (!channels?.length) return [];
+  const total = channels.reduce((sum, channel) => sum + Math.max(0, Number(channel.share ?? 0)), 0);
+  let remainder = 100;
+  return channels.map((channel, index) => {
+    const baseShare = total > 0 ? (Math.max(0, Number(channel.share ?? 0)) / total) * 100 : 100 / channels.length;
+    const value = index === channels.length - 1 ? Math.max(0, remainder) : Math.min(remainder, Math.round(baseShare));
+    remainder -= value;
+    return {
+      ...channel,
+      id: channel.id ?? `traffic-${index}`,
+      share: Number.isFinite(value) ? value : 0,
+    };
+  });
+}
+
+export function emphasizeByRank(channels, { top = 2, boost = 1.2, tail = 0.9 } = {}) {
+  if (!channels?.length) return [];
+  const normalized = normalizeShares(channels);
+  const indices = normalized
+    .map((channel, index) => ({ index, share: channel.share ?? 0 }))
+    .sort((a, b) => b.share - a.share)
+    .map((item) => item.index);
+  const weights = normalized.map(() => tail);
+  indices.forEach((index, position) => {
+    weights[index] = position < top ? boost : tail;
+  });
+  const weighted = normalized.map((channel, index) => ({
+    ...channel,
+    share: (channel.share ?? 0) * (weights[index] ?? 1),
+  }));
+  return normalizeShares(weighted);
+}
+
+export function emphasizeKeywords(
+  channels,
+  { positivePattern, positiveWeight = 1.25, fallbackWeight = 0.9 } = {},
+) {
+  if (!channels?.length) return [];
+  const normalized = normalizeShares(channels);
+  const weighted = normalized.map((channel, index) => {
+    const identifier = `${channel.id ?? ''} ${channel.name ?? ''}`.toLowerCase();
+    const isPositive = positivePattern?.test(identifier) ?? false;
+    return {
+      ...channel,
+      share: (channel.share ?? 0) * (isPositive ? positiveWeight : fallbackWeight),
+      id: channel.id ?? `traffic-${index}`,
+    };
+  });
+  return normalizeShares(weighted);
+}
+
+export function getBudgetClassification(share) {
+  if (share == null || Number.isNaN(share)) {
+    return { label: '—', status: 'Нет данных по бюджету.' };
+  }
+  if (share < 0.05) {
+    return { label: 'Критический минимум', status: 'Инвестиции <5% — маркетинг почти отсутствует.' };
+  }
+  if (share < 0.1) {
+    return { label: 'На плаву', status: '5–10% от выручки — поддерживаем продажи и узнаваемость.' };
+  }
+  if (share < 0.15) {
+    return { label: 'Умеренный рост', status: '10% от выручки — планомерно растим спрос.' };
+  }
+  return { label: 'Агрессивный рост', status: 'Более 15% — ставка на масштабирование и долю рынка.' };
+}
+
+export const scenarioArchetypeMeta = {
+  base: {
+    shareOfRevenue: 0.05,
+    label: 'На плаву',
+    status: '5% от выручки — поддерживаем стабильность воронки.',
+    description: 'Базовый режим: держим основные каналы и фокус на эффективности.',
+    plays: ['Тонкая настройка unit-экономики', 'Локальные эксперименты без резких вложений'],
+    trafficStrategy: (channels) => normalizeShares(channels),
+  },
+  moderate: {
+    shareOfRevenue: 0.1,
+    label: 'Умеренный рост',
+    status: '10% от выручки — активируем новые сегменты и эксперименты.',
+    description: 'Подключаем дополнительные кампании и автоматизации для роста.',
+    plays: ['Перезапуск лид-магнитов и контента', 'CRM-автоматизация nurture-цепочек'],
+    trafficStrategy: (channels) => emphasizeByRank(channels, { top: 2, boost: 1.18, tail: 0.95 }),
+  },
+  aggressive: {
+    shareOfRevenue: 0.18,
+    label: 'Агрессивный рост',
+    status: 'Инвестируем >15% выручки для быстрого масштабирования.',
+    description: 'Ускоряем performance, ABM и product-led инициативы.',
+    plays: ['Performance-спринты и ростовые эксперименты каждую неделю', 'Глубокая аналитика CAC/LTV и cohort management'],
+    trafficStrategy: (channels) =>
+      emphasizeKeywords(channels, {
+        positivePattern: /(paid|performance|ads|abm|outbound|events|demand|growth|launch|promo)/i,
+        positiveWeight: 1.35,
+        fallbackWeight: 0.8,
+      }),
+  },
+  land: {
+    shareOfRevenue: 0.12,
+    label: 'Land & Expand',
+    status: '12% от выручки — удержание, лояльность и расширение внутри клиентов.',
+    description: 'Customer marketing, upsell и программы рекомендаций становятся основой роста.',
+    plays: ['Quarterly business review и customer marketing', 'Программы лояльности и петли рекомендаций'],
+    trafficStrategy: (channels) =>
+      emphasizeKeywords(channels, {
+        positivePattern: /(retention|ref|loyal|crm|community|success|customer|advocacy|partner)/i,
+        positiveWeight: 1.3,
+        fallbackWeight: 0.9,
+      }),
+  },
+  sales: {
+    shareOfRevenue: 0.03,
+    label: 'Только продажи',
+    status: 'Маркетинг <5% — упор на SDR и холодные касания.',
+    description: 'Маркетинг практически отсутствует: работаем через холодные продажи и партнерские сделки.',
+    plays: ['Обновление SDR playbook и скриптов', 'Sales enablement вместо маркетинговых активностей'],
+    trafficStrategy: () => [
+      {
+        id: 'cold-outbound',
+        name: 'Холодный outbound',
+        share: 55,
+        note: 'SDR-каденции, LinkedIn outreach, звонки.',
+      },
+      {
+        id: 'email-sequences',
+        name: 'Email-серии и nurture',
+        share: 25,
+        note: 'Мультиканальные письма, автоматические follow-up.',
+      },
+      {
+        id: 'partner-intros',
+        name: 'Партнеры и выездные встречи',
+        share: 20,
+        note: 'Партнерские интро, демо на площадке клиента.',
+      },
+    ],
+  },
+};
+
+export function detectScenarioArchetype(scenario) {
+  if (!scenario) return 'base';
+  const key = `${scenario.id ?? ''} ${scenario.name ?? ''}`.toLowerCase();
+  if (/(sales|no-marketing|cold|outbound-only|bare|только продаж)/.test(key)) {
+    return 'sales';
+  }
+  if (/(land|expand|retention|loyal|aftermarket|referral|alumni|service|telemed|enterprise|partner|grant|success|mastermind|loyalty|alliance)/.test(key)) {
+    return 'land';
+  }
+  if (/(aggressive|hyper|scale|max|rocket|blitz|accelerate)/.test(key)) {
+    return 'aggressive';
+  }
+  if (/(growth|improved|evergreen|launch|digitization|promo|telemed|service|boost|expansion|animation|productized|digitization)/.test(key)) {
+    return 'moderate';
+  }
+  if (/(default|base|current|standard|steady|now|текущ)/.test(key)) {
+    return 'base';
+  }
+  return 'moderate';
+}
+
+export function getScenarioMeta(scenario, fallbackChannels) {
+  if (!scenario) {
+    const meta = scenarioArchetypeMeta.base;
+    return {
+      shareOfRevenue: meta.shareOfRevenue,
+      label: meta.label,
+      status: meta.status,
+      description: meta.description,
+      plays: meta.plays,
+      trafficMix: meta.trafficStrategy(fallbackChannels),
+    };
+  }
+  const archetype = detectScenarioArchetype(scenario);
+  const baseMeta = scenarioArchetypeMeta[archetype] ?? scenarioArchetypeMeta.base;
+  const share = scenario.budget?.shareOfRevenue ?? baseMeta.shareOfRevenue;
+  const classification = getBudgetClassification(share);
+  const trafficMix = scenario.trafficMix?.length
+    ? normalizeShares(scenario.trafficMix)
+    : baseMeta.trafficStrategy(fallbackChannels);
+  return {
+    shareOfRevenue: share,
+    label: scenario.budget?.label ?? baseMeta.label ?? classification.label,
+    status: scenario.budget?.note ?? baseMeta.status ?? classification.status,
+    description: scenario.description ?? baseMeta.description,
+    plays: scenario.plays ?? baseMeta.plays,
+    trafficMix,
+  };
+}
+
+export const conversionFromValues = (current, previous) => {
+  if (!previous || previous === 0) return 100;
+  return (current / previous) * 100;
+};
+
+export function calculateMetrics({ state, scenario, scenarioMeta, activeLevers, numberFormatter }) {
+  const scenarioAdjustments = scenario?.adjustments ?? {};
+  const scenarioZoneAdjustments = scenario?.zones ?? {};
+  const leverMap = (state.levers ?? []).reduce((acc, lever) => {
+    if (activeLevers?.has?.(lever.id)) {
+      acc[lever.stageId] = (acc[lever.stageId] ?? 0) + (lever.conversionBoost ?? 0);
+    }
+    return acc;
+  }, {});
+
+  const baseStages = [];
+  const improvedStages = [];
+
+  let previousBaseValue = null;
+  let previousImprovedValue = null;
+
+  state.stages.forEach((stage, index) => {
+    const prevBase = previousBaseValue ?? stage.value;
+    const effectiveConversion =
+      index === 0
+        ? 100
+        : stage.mode === 'percent'
+          ? stage.conversion ?? conversionFromValues(stage.value, previousBaseValue ?? stage.value)
+          : conversionFromValues(stage.value, previousBaseValue ?? stage.value);
+    const zoneAdjustment = scenarioZoneAdjustments?.[stage.zoneId] ?? {};
+    const scenarioBoost = (scenarioAdjustments?.[stage.id]?.conversion ?? 0) + (zoneAdjustment.conversion ?? 0);
+    const scenarioValueBoost = (scenarioAdjustments?.[stage.id]?.value ?? 0) + (zoneAdjustment.value ?? 0);
+    const leverBoost = leverMap?.[stage.id] ?? 0;
+
+    const baseValue =
+      index === 0 || stage.mode === 'absolute'
+        ? stage.value
+        : (previousBaseValue ?? 0) * (effectiveConversion / 100);
+
+    const baseConversion =
+      index === 0
+        ? 100
+        : stage.mode === 'absolute'
+          ? conversionFromValues(stage.value, previousBaseValue ?? stage.value)
+          : effectiveConversion;
+
+    const improvedConversionRaw = index === 0 ? 100 + scenarioValueBoost : baseConversion + scenarioBoost + leverBoost;
+    const improvedConversion =
+      index === 0 && stage.mode === 'absolute'
+        ? Math.max(1, improvedConversionRaw)
+        : Math.max(0, Math.min(100, improvedConversionRaw));
+
+    const improvedBase =
+      index === 0
+        ? stage.value * (1 + scenarioValueBoost / 100)
+        : stage.mode === 'absolute'
+          ? stage.value * (1 + scenarioValueBoost / 100)
+          : (previousImprovedValue ?? 0) * (improvedConversion / 100);
+
+    const benchmark = stage.benchmark ?? null;
+    const drop = index === 0 ? 0 : Math.max(0, (previousBaseValue ?? baseValue) - baseValue);
+    const improvedDrop = index === 0 ? 0 : Math.max(0, (previousImprovedValue ?? improvedBase) - improvedBase);
+
+    const stageMetrics = {
+      ...stage,
+      index,
+      baseValue,
+      baseConversion,
+      improvedValue: improvedBase,
+      improvedConversion,
+      benchmark,
+      drop,
+      improvedDrop,
+      scenarioBoost,
+      leverBoost,
+    };
+
+    baseStages.push(stageMetrics);
+    improvedStages.push(stageMetrics);
+
+    previousBaseValue = baseValue;
+    previousImprovedValue = improvedBase;
+  });
+
+  const topValue = baseStages[0]?.baseValue ?? 0;
+  const finalBase = baseStages[baseStages.length - 1]?.baseValue ?? 0;
+  const finalImproved = improvedStages[improvedStages.length - 1]?.improvedValue ?? 0;
+  const deltaUnits = finalImproved - finalBase;
+  const deltaPercent = finalBase > 0 ? (deltaUnits / finalBase) * 100 : 0;
+
+  const marketingStage = baseStages[1] ?? baseStages[0];
+  const marketingLeads = marketingStage?.baseValue ?? 0;
+  const improvedMarketingLeads = marketingStage?.improvedValue ?? marketingLeads;
+
+  const dealsBase = finalBase;
+  const dealsImproved = finalImproved;
+  const revenueBase = dealsBase * (state.finances?.avgCheck ?? 0);
+  const revenueImproved = dealsImproved * (state.finances?.avgCheck ?? 0);
+  const budgetShare = scenarioMeta?.shareOfRevenue ?? null;
+  const spendBase =
+    budgetShare != null
+      ? revenueBase * budgetShare
+      : marketingLeads * (state.finances?.cpl ?? 0);
+  const spendImproved =
+    budgetShare != null
+      ? revenueImproved * budgetShare
+      : improvedMarketingLeads * (state.finances?.cpl ?? 0);
+  const cac = state.finances?.cac ?? 0;
+  const ltv = state.finances?.ltv ?? 0;
+  const grossMarginBase = revenueBase - spendBase - dealsBase * cac;
+  const grossMarginImproved = revenueImproved - spendImproved - dealsImproved * cac;
+  const roiBase = spendBase > 0 ? (grossMarginBase / spendBase) * 100 : 0;
+  const roiImproved = spendImproved > 0 ? (grossMarginImproved / spendImproved) * 100 : 0;
+  const paybackMonths = cac > 0 ? (state.finances?.avgCheck > 0 ? state.finances.avgCheck / cac : 0) : 0;
+
+  const bottleneck = baseStages
+    .slice(1)
+    .reduce((worst, stage) => {
+      if (!worst || stage.drop > worst.drop) return stage;
+      return worst;
+    }, null);
+
+  const formatter = numberFormatter ?? new Intl.NumberFormat('ru-RU', { maximumFractionDigits: 1 });
+  const insight = bottleneck
+    ? `Самая большая потеря (${formatter.format(bottleneck.drop)}) на этапе «${bottleneck.name}». Улучшение конверсии на 5 п.п. даст дополнительно ~${formatter.format((baseStages[bottleneck.index - 1]?.baseValue ?? 0) * 0.05)} лидов.`
+    : 'Воронка стабильна, улучшайте верх и удержание одновременно.';
+
+  const retentionStages = baseStages.filter((stage) => stage.zoneId === 'retention');
+  let churnRate = null;
+  let churnRateImproved = null;
+  let retentionSummary = null;
+
+  if (retentionStages.length) {
+    const firstRetention = retentionStages[0];
+    const previousStage = firstRetention.index > 0 ? baseStages[firstRetention.index - 1] : null;
+    const baseCustomers = previousStage?.baseValue ?? firstRetention.baseValue ?? 0;
+    const lastRetention = retentionStages[retentionStages.length - 1];
+    const retainedBase = lastRetention?.baseValue ?? 0;
+    const retainedImproved = lastRetention?.improvedValue ?? retainedBase;
+
+    if (baseCustomers > 0) {
+      churnRate = Math.max(0, Math.min(100, ((baseCustomers - retainedBase) / baseCustomers) * 100));
+      churnRateImproved = Math.max(
+        0,
+        Math.min(100, ((baseCustomers - retainedImproved) / baseCustomers) * 100),
+      );
+    } else {
+      churnRate = 0;
+      churnRateImproved = 0;
+    }
+
+    const loyalShare = baseCustomers > 0 ? Math.max(0, Math.min(100, (retainedBase / baseCustomers) * 100)) : 0;
+    const loyalShareImproved =
+      baseCustomers > 0 ? Math.max(0, Math.min(100, (retainedImproved / baseCustomers) * 100)) : loyalShare;
+    const atRiskShare = Math.max(0, Math.min(100, (churnRate ?? 0) * 0.55));
+    const atRiskShareImproved = Math.max(0, Math.min(100, (churnRateImproved ?? 0) * 0.45));
+    const sleepingShare = Math.max(0, Math.min(100, 100 - loyalShare - atRiskShare - (churnRate ?? 0)));
+    const sleepingShareImproved = Math.max(
+      0,
+      Math.min(100, 100 - loyalShareImproved - atRiskShareImproved - (churnRateImproved ?? 0)),
+    );
+
+    retentionSummary = {
+      baseCustomers,
+      loyalShare,
+      loyalShareImproved,
+      atRiskShare,
+      atRiskShareImproved,
+      sleepingShare,
+      sleepingShareImproved,
+      churnRate: churnRate ?? 0,
+      churnRateImproved: churnRateImproved ?? 0,
+    };
+  }
+
+  return {
+    stages: baseStages,
+    topValue,
+    finalBase,
+    finalImproved,
+    deltaUnits,
+    deltaPercent,
+    spendBase,
+    spendImproved,
+    marketingBudgetShare: budgetShare,
+    marketingBudgetLabel: scenarioMeta?.label,
+    marketingBudgetStatus: scenarioMeta?.status,
+    scenarioDescription: scenarioMeta?.description,
+    scenarioPlays: scenarioMeta?.plays,
+    trafficMix: scenarioMeta?.trafficMix,
+    revenueBase,
+    revenueImproved,
+    roiBase,
+    roiImproved,
+    paybackMonths,
+    grossMarginBase,
+    grossMarginImproved,
+    bottleneck,
+    insight,
+    churnRate,
+    churnRateImproved,
+    retentionSummary,
+    ltv,
+  };
+}


### PR DESCRIPTION
## Summary
- extract funnel normalization and metrics helpers into a reusable utilities module
- add a dedicated comparison view that lets users load two funnels and see side-by-side insights
- wire the existing experience to the shared metrics calculator and expose new translations for the compare mode

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ef564e27548320be377cdff6e41502