### PR TITLE
Adjust calculator base defaults

### DIFF
--- a/src/components/calculator/CalculatorPage.jsx
+++ b/src/components/calculator/CalculatorPage.jsx
@@ -67,7 +67,7 @@ function createInitialState() {
     speedId: speedOptions[0]?.id ?? 'normal',
     creativeCount: baseProduct?.supportsCreatives ? baseProduct.defaultCreativeCount ?? 1 : 1,
     selectedFormats: formatOptions.filter((item) => item.defaultSelected).map((item) => item.id),
-    selectedServices: serviceOptions.filter((item) => item.defaultSelected).map((item) => item.id),
+    selectedServices: [],
     voiceoverType:
       voiceoverService?.defaultVoice ?? voiceoverService?.voiceOptions?.[0]?.id ?? 'female',
     revisionIterations: 2,

--- a/src/data/calculatorConfig.js
+++ b/src/data/calculatorConfig.js
@@ -4,7 +4,7 @@ export const productTypes = [
     label: 'Один обучающий ролик (1–5 мин)',
     description: 'Глубокий обучающий ролик для внутренних команд или клиентов.',
     basePrice: 0,
-    pricePerMinute: 174960,
+    pricePerMinute: 175000,
     baseTimeline: 18,
     timelinePerMinute: 0.8,
     baseTeamHours: 120,


### PR DESCRIPTION
## Summary
- clear default service selections so the calculator starts without prechecked stages and services
- update the base per-minute rate for single videos to reflect the intended 1-minute cost

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69242a0697888320b00701c4aa5bb951)