### PR TITLE
Adjust services calculator defaults

### DIFF
--- a/src/components/calculator/CalculatorPage.jsx
+++ b/src/components/calculator/CalculatorPage.jsx
@@ -259,13 +259,10 @@ export function calculateSummary({
     }
   });
 
-  const animationEvaluation = serviceEvaluations.get('animation');
-  const animationSelected = serviceSet.has('animation');
   const includedIterations = iterationService?.included ?? 0;
   const extraIterations = Math.max(0, revisionIterations - includedIterations);
-  const iterationCost = (animationSelected ? (animationEvaluation?.cost ?? 0) : 0) *
-    (iterationService?.percentPerExtra ?? 0) *
-    extraIterations;
+  const iterationBaseCost = serviceEvaluations.get('animation')?.cost ?? baseCost;
+  const iterationCost = iterationBaseCost * (iterationService?.percentPerExtra ?? 0) * extraIterations;
   if (iterationService) {
     const evaluation = {
       cost: iterationCost,
@@ -643,6 +640,10 @@ function CalculatorPage() {
                   onChange={(event) => setDurationSeconds(Number(event.target.value))}
                   className="mt-3 h-2 w-full cursor-pointer appearance-none rounded-full bg-slate-700 accent-cyan-400"
                 />
+                <p className="mt-2 text-xs text-slate-400">
+                  В стоимость входят услуги полного цикла: композитинг, финальная сборка, анимация, монтаж,
+                  создание раскадровки и другие этапы производства.
+                </p>
               </div>
 
               <div>
@@ -668,7 +669,7 @@ function CalculatorPage() {
               {product.supportsCreatives && (
                 <div>
                   <label className="flex items-center justify-between text-sm text-slate-300">
-                    <span>Количество креативов</span>
+                    <span>Указать количество креативов</span>
                     <input
                       type="number"
                       min={1}
@@ -823,22 +824,6 @@ function CalculatorPage() {
               <div className="flex items-baseline justify-between gap-4">
                 <dt className="text-slate-300">💰 Итоговая стоимость</dt>
                 <dd className="text-xl font-semibold text-slate-50">{formatCurrency(summary.totals.totalCost)}</dd>
-              </div>
-              <div className="flex items-baseline justify-between gap-4">
-                <dt className="text-slate-300">⏱️ Срок производства</dt>
-                <dd className="text-base font-medium text-slate-100">{summary.totals.timelineDays} дней</dd>
-              </div>
-              <div className="flex items-baseline justify-between gap-4">
-                <dt className="text-slate-300">👥 Загрузка команды</dt>
-                <dd className="text-base font-medium text-slate-100">{summary.totals.teamLoadPercent}%</dd>
-              </div>
-              <div className="flex items-baseline justify-between gap-4">
-                <dt className="text-slate-300">🧠 Экономия клиента</dt>
-                <dd className="text-base font-medium text-emerald-200">{summary.totals.savingsSummary}</dd>
-              </div>
-              <div className="flex items-baseline justify-between gap-4">
-                <dt className="text-slate-300">📊 Окупаемость (ROI)</dt>
-                <dd className="text-base font-medium text-indigo-200">{summary.totals.roi}%</dd>
               </div>
             </dl>
             <div className="mt-5 space-y-3 rounded-2xl border border-slate-800 bg-slate-900/60 p-4">

--- a/src/data/calculatorConfig.js
+++ b/src/data/calculatorConfig.js
@@ -200,27 +200,6 @@ export const serviceOptions = [
     },
   },
   {
-    id: 'animation',
-    label: '🎨 Анимация и монтаж',
-    description: 'Полный цикл производства, композитинг и финальная сборка.',
-    price: 65000,
-    pricePerMinute: 23400,
-    teamLoad: 12,
-    teamHours: 60,
-    hoursPerMinute: 18,
-    timeline: 7,
-    clientSavings: { time: 9, budget: 6, risk: 10, hours: 16, money: 110500 },
-    roiBoost: 14,
-    defaultSelected: true,
-    perCreative: true,
-    funnelImpact: {
-      stageConversions: {
-        proposal: 1.1,
-        deals: 1,
-      },
-    },
-  },
-  {
     id: 'voiceover',
     label: '🎙️ Озвучка',
     description: 'Профессиональная запись или нейросеть — выберите формат.',
@@ -233,7 +212,7 @@ export const serviceOptions = [
     voiceOptions: [
       { id: 'female', label: 'Женский голос', price: 13000 },
       { id: 'male', label: 'Мужской голос', price: 13000 },
-      { id: 'neural', label: 'Нейросеть', price: 13000 },
+      { id: 'neural', label: 'Нейросеть', price: 5000 },
     ],
     defaultVoice: 'female',
     funnelImpact: {
@@ -245,7 +224,7 @@ export const serviceOptions = [
   {
     id: 'iterations',
     label: '🔄 Количество итераций правок',
-    description: 'Две итерации включены, каждая дополнительная — +20% от стоимости анимации и монтажа.',
+    description: 'Две итерации включены, каждая дополнительная — +20% от стоимости производства.',
     included: 2,
     percentPerExtra: 0.2,
     defaultSelected: true,


### PR DESCRIPTION
## Summary
- remove the separate animation/montage add-on and clarify that full production is included under duration
- lower the neural voiceover option price and update revision iteration pricing description
- trim project summary to cost-only and improve creative count input label

## Testing
- npm test -- --runInBand *(fails: vitest command not found in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69369cc0710083209b6887eec48dcf01)